### PR TITLE
fix: Unmarshal should fail if required fields are missing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ run:
   timeout: 10m
   skip-files:
     - ".*\\.pb.*\\.go"
+    - ".*_test\\.go"
 
 # output configuration options
 output:

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,8 @@ clean-generated:
 
 .PHONY: lint
 lint: check-golangci-lint-install
-	@golangci-lint run
+	@golangci-lint run ./...
+	@cd example && golangci-lint run ./...
 
 .PHONY: check-golangci-lint-install
 check-golangci-lint-install:

--- a/cmd/protoc-gen-fastmarshal/templates/permessage.go.tmpl
+++ b/cmd/protoc-gen-fastmarshal/templates/permessage.go.tmpl
@@ -7,7 +7,8 @@
 package {{ .ProtoDesc.GoPackageName }}
 
 import (
-    "fmt"
+    "fmt"{{if and (eq $protoSyntax "proto2") (hasRequiredFields nil)}}
+    "strings"{{end}}
     "github.com/CrowdStrike/csproto"
     {{range (.Message | getAdditionalImports)}}{{.}}
     {{end}}
@@ -114,7 +115,39 @@ func (m *{{ .Message.GoIdent.GoName}}) Unmarshal(p []byte) error {
             {{- end -}}
             }
         }
+    }{{if hasRequiredFields .Message }}
+    // verify required fields are assigned
+    if err := m.csprotoCheckRequiredFields(); err != nil {
+        return err
+    }
+    {{end}}
+    return nil
+}
+{{if hasRequiredFields .Message}}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *{{.Message.GoIdent.GoName}}) csprotoCheckRequiredFields() error {
+    var missingFields []string
+{{ range .Message.Fields }}
+{{ if and (eq (.Desc.Cardinality | string) "required") (eq (.Desc.Syntax | string) "proto2") -}}
+    if m.{{.GoName}} == nil {
+        missingFields = append(missingFields, "{{.GoName}}")
+    }
+{{- end -}}
+{{ end }}
+    if len(missingFields) > 0 {
+        var sb strings.Builder
+        sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+        for i, s := range missingFields {
+            if i > 0 {
+                sb.WriteRune(',')
+            }
+            sb.WriteString(s)
+        }
+        return fmt.Errorf(sb.String())
     }
     return nil
 }
+{{ end }}
 {{end}}

--- a/cmd/protoc-gen-fastmarshal/templates/singlefile.go.tmpl
+++ b/cmd/protoc-gen-fastmarshal/templates/singlefile.go.tmpl
@@ -7,7 +7,8 @@
 package {{ .ProtoDesc.GoPackageName }}
 
 import (
-    "fmt"
+    "fmt"{{if and (eq $protoSyntax "proto2") (hasRequiredFields nil)}}
+    "strings"{{end}}
     "github.com/CrowdStrike/csproto"
     {{range (allMessages | getAdditionalImports)}}{{.}}
     {{end}}
@@ -117,8 +118,40 @@ func (m *{{ .GoIdent.GoName}}) Unmarshal(p []byte) error {
             {{- end -}}
             }
         }
+    }{{if hasRequiredFields . }}
+    // verify required fields are assigned
+    if err := m.csprotoCheckRequiredFields(); err != nil {
+        return err
+    }
+    {{end}}
+    return nil
+}
+{{if hasRequiredFields .}}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *{{.GoIdent.GoName}}) csprotoCheckRequiredFields() error {
+    var missingFields []string
+{{ range .Fields }}
+{{ if and (eq (.Desc.Cardinality | string) "required") (eq (.Desc.Syntax | string) "proto2") -}}
+    if m.{{.GoName}} == nil {
+        missingFields = append(missingFields, "{{.GoName}}")
+    }
+{{- end -}}
+{{ end }}
+    if len(missingFields) > 0 {
+        var sb strings.Builder
+        sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+        for i, s := range missingFields {
+            if i > 0 {
+                sb.WriteRune(',')
+            }
+            sb.WriteString(s)
+        }
+        return fmt.Errorf(sb.String())
     }
     return nil
 }
+{{ end }}
 {{ end }}
 {{end}}

--- a/example/proto2/gogo/gogo_proto2_example.pb.fm.go
+++ b/example/proto2/gogo/gogo_proto2_example.pb.fm.go
@@ -5,6 +5,7 @@ package gogo
 
 import (
 	"fmt"
+	"strings"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -171,6 +172,42 @@ func (m *BaseEvent) Unmarshal(p []byte) error {
 				m.XXX_unrecognized = append(m.XXX_unrecognized, skipped...)
 			}
 		}
+	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *BaseEvent) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.EventID == nil {
+		missingFields = append(missingFields, "EventID")
+	}
+	if m.SourceID == nil {
+		missingFields = append(missingFields, "SourceID")
+	}
+	if m.Timestamp == nil {
+		missingFields = append(missingFields, "Timestamp")
+	}
+	if m.EventType == nil {
+		missingFields = append(missingFields, "EventType")
+	}
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
 	}
 	return nil
 }
@@ -413,6 +450,34 @@ func (m *TestEvent) Unmarshal(p []byte) error {
 			}
 		}
 	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *TestEvent) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.Embedded == nil {
+		missingFields = append(missingFields, "Embedded")
+	}
+
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
+	}
 	return nil
 }
 
@@ -556,6 +621,34 @@ func (m *EmbeddedEvent) Unmarshal(p []byte) error {
 				m.XXX_unrecognized = append(m.XXX_unrecognized, skipped...)
 			}
 		}
+	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *EmbeddedEvent) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.ID == nil {
+		missingFields = append(missingFields, "ID")
+	}
+
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
 	}
 	return nil
 }
@@ -903,6 +996,34 @@ func (m *AllTheThings) Unmarshal(p []byte) error {
 				m.XXX_unrecognized = append(m.XXX_unrecognized, skipped...)
 			}
 		}
+	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *AllTheThings) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.ID == nil {
+		missingFields = append(missingFields, "ID")
+	}
+
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
 	}
 	return nil
 }
@@ -1332,6 +1453,34 @@ func (m *RepeatAllTheThings) Unmarshal(p []byte) error {
 				m.XXX_unrecognized = append(m.XXX_unrecognized, skipped...)
 			}
 		}
+	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *RepeatAllTheThings) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.ID == nil {
+		missingFields = append(missingFields, "ID")
+	}
+
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
 	}
 	return nil
 }

--- a/example/proto2/googlev1/googlev1_proto2_example.pb.fm.go
+++ b/example/proto2/googlev1/googlev1_proto2_example.pb.fm.go
@@ -5,6 +5,7 @@ package googlev1
 
 import (
 	"fmt"
+	"strings"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -171,6 +172,42 @@ func (m *BaseEvent) Unmarshal(p []byte) error {
 				m.unknownFields = append(m.unknownFields, skipped...)
 			}
 		}
+	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *BaseEvent) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.EventID == nil {
+		missingFields = append(missingFields, "EventID")
+	}
+	if m.SourceID == nil {
+		missingFields = append(missingFields, "SourceID")
+	}
+	if m.Timestamp == nil {
+		missingFields = append(missingFields, "Timestamp")
+	}
+	if m.EventType == nil {
+		missingFields = append(missingFields, "EventType")
+	}
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
 	}
 	return nil
 }
@@ -413,6 +450,34 @@ func (m *TestEvent) Unmarshal(p []byte) error {
 			}
 		}
 	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *TestEvent) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.Embedded == nil {
+		missingFields = append(missingFields, "Embedded")
+	}
+
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
+	}
 	return nil
 }
 
@@ -556,6 +621,34 @@ func (m *EmbeddedEvent) Unmarshal(p []byte) error {
 				m.unknownFields = append(m.unknownFields, skipped...)
 			}
 		}
+	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *EmbeddedEvent) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.ID == nil {
+		missingFields = append(missingFields, "ID")
+	}
+
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
 	}
 	return nil
 }
@@ -903,6 +996,34 @@ func (m *AllTheThings) Unmarshal(p []byte) error {
 				m.unknownFields = append(m.unknownFields, skipped...)
 			}
 		}
+	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *AllTheThings) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.ID == nil {
+		missingFields = append(missingFields, "ID")
+	}
+
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
 	}
 	return nil
 }
@@ -1332,6 +1453,34 @@ func (m *RepeatAllTheThings) Unmarshal(p []byte) error {
 				m.unknownFields = append(m.unknownFields, skipped...)
 			}
 		}
+	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *RepeatAllTheThings) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.ID == nil {
+		missingFields = append(missingFields, "ID")
+	}
+
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
 	}
 	return nil
 }

--- a/example/proto2/googlev2/googlev2_proto2_example.pb.fm.go
+++ b/example/proto2/googlev2/googlev2_proto2_example.pb.fm.go
@@ -5,6 +5,7 @@ package googlev2
 
 import (
 	"fmt"
+	"strings"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -171,6 +172,42 @@ func (m *BaseEvent) Unmarshal(p []byte) error {
 				m.unknownFields = append(m.unknownFields, skipped...)
 			}
 		}
+	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *BaseEvent) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.EventID == nil {
+		missingFields = append(missingFields, "EventID")
+	}
+	if m.SourceID == nil {
+		missingFields = append(missingFields, "SourceID")
+	}
+	if m.Timestamp == nil {
+		missingFields = append(missingFields, "Timestamp")
+	}
+	if m.EventType == nil {
+		missingFields = append(missingFields, "EventType")
+	}
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
 	}
 	return nil
 }
@@ -413,6 +450,34 @@ func (m *TestEvent) Unmarshal(p []byte) error {
 			}
 		}
 	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *TestEvent) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.Embedded == nil {
+		missingFields = append(missingFields, "Embedded")
+	}
+
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
+	}
 	return nil
 }
 
@@ -556,6 +621,34 @@ func (m *EmbeddedEvent) Unmarshal(p []byte) error {
 				m.unknownFields = append(m.unknownFields, skipped...)
 			}
 		}
+	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *EmbeddedEvent) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.ID == nil {
+		missingFields = append(missingFields, "ID")
+	}
+
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
 	}
 	return nil
 }
@@ -903,6 +996,34 @@ func (m *AllTheThings) Unmarshal(p []byte) error {
 				m.unknownFields = append(m.unknownFields, skipped...)
 			}
 		}
+	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *AllTheThings) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.ID == nil {
+		missingFields = append(missingFields, "ID")
+	}
+
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
 	}
 	return nil
 }
@@ -1332,6 +1453,34 @@ func (m *RepeatAllTheThings) Unmarshal(p []byte) error {
 				m.unknownFields = append(m.unknownFields, skipped...)
 			}
 		}
+	}
+	// verify required fields are assigned
+	if err := m.csprotoCheckRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// csprotoCheckRequiredFields is called by Unmarshal() to ensure that all required fields have been
+// populated.
+func (m *RepeatAllTheThings) csprotoCheckRequiredFields() error {
+	var missingFields []string
+
+	if m.ID == nil {
+		missingFields = append(missingFields, "ID")
+	}
+
+	if len(missingFields) > 0 {
+		var sb strings.Builder
+		sb.WriteString("cannot unmarshal, one or more required fields missing: ")
+		for i, s := range missingFields {
+			if i > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(s)
+		}
+		return fmt.Errorf(sb.String())
 	}
 	return nil
 }

--- a/example/proto2_googlev1_test.go
+++ b/example/proto2_googlev1_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/CrowdStrike/csproto"
 	"github.com/CrowdStrike/csproto/example/proto2/googlev1"
@@ -42,6 +43,27 @@ func TestProto2GoogleV1Message(t *testing.T) {
 			t.Errorf("Mismatched data after unmarshal\n\tExpected: %s\n\t     Got: %s\n", msg.String(), msg2.String())
 		}
 	})
+}
+
+func TestMarshalFailsOnMissingRequiredFieldForGoogleV1Message(t *testing.T) {
+	msg := createTestProto2GoogleV1Message()
+	msg.EventID = nil
+
+	_, err := csproto.Marshal(msg)
+	assert.Error(t, err)
+}
+
+func TestUnmarshalFailsOnMissingRequiredFieldForGoogleV1Message(t *testing.T) {
+	// encoded contents of a minimal BaseEvent with EventID removed
+	data := []byte{
+		0x12, 0xb, 0x74, 0x65, 0x73, 0x74, 0x2d, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x18, 0xc3, 0xbc,
+		0xdc, 0x92, 0x6, 0x20, 0x1, 0xa2, 0x6, 0x4, 0x2a, 0x2, 0x8, 0x2a,
+	}
+	var msg googlev1.BaseEvent
+
+	err := csproto.Unmarshal(data, &msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "one or more required fields missing")
 }
 
 func createTestProto2GoogleV1Message() *googlev1.BaseEvent {

--- a/example/proto2_googlev2_test.go
+++ b/example/proto2_googlev2_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/CrowdStrike/csproto"
@@ -42,6 +43,27 @@ func TestProto2GoogleV2Message(t *testing.T) {
 			t.Errorf("Mismatched data after unmarshal\n\tExpected: %s\n\t     Got: %s\n", msg.String(), msg2.String())
 		}
 	})
+}
+
+func TestMarshalFailsOnMissingRequiredFieldForGoogleV2Message(t *testing.T) {
+	msg := createTestProto2GoogleV2Message()
+	msg.EventID = nil
+
+	_, err := csproto.Marshal(msg)
+	assert.Error(t, err)
+}
+
+func TestUnmarshalFailsOnMissingRequiredFieldForGoogleV2Message(t *testing.T) {
+	// encoded contents of a minimal BaseEvent with EventID removed
+	data := []byte{
+		0x12, 0xb, 0x74, 0x65, 0x73, 0x74, 0x2d, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x18, 0xc3, 0xbc,
+		0xdc, 0x92, 0x6, 0x20, 0x1, 0xa2, 0x6, 0x4, 0x2a, 0x2, 0x8, 0x2a,
+	}
+	var msg googlev2.BaseEvent
+
+	err := csproto.Unmarshal(data, &msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "one or more required fields missing")
 }
 
 func createTestProto2GoogleV2Message() *googlev2.BaseEvent {


### PR DESCRIPTION
- updated codegen templates to emit checks that all required fields are assigned during unmarshal
- added associated tests
- regenerated all examples
    
Resolves #12

This PR also includes tweaks to the linter setup (see #2) so that we also lint the nested module in `example/` and skip linting test files