### PR TITLE
feat: integrate Goreleaser for building binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: build-binary-artifacts
+
+on:
+  # run when a release is published
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch all tags
+        run: git fetch --force --tags
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # build/test outputs
 bin/
+dist/
 *.test
 *profile.out
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,46 @@
+project_name: csproto
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - id: protoc-gen-fastmarshal
+    main: ./cmd/protoc-gen-fastmarshal
+    binary: protoc-gen-fastmarshal
+    flags:
+      - -trimpath
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - '386'
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - '6'
+      - '7'
+    goos:
+      - linux
+      - darwin
+      - windows
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incminor .Version }}-pre.{{.Timestamp}}.{{.ShortCommit}}"
+changelog:
+  use: github-native
+  filters:
+    exclude:
+      - '^(docs|test)(\\(.+\\))?:'
+release:
+  prerelease: auto
+  mode: append

--- a/Makefile
+++ b/Makefile
@@ -143,5 +143,15 @@ lint: check-golangci-lint-install
 .PHONY: check-golangci-lint-install
 check-golangci-lint-install:
 ifeq ("$(shell command -v golangci-lint)", "")
-	$(error golangci-lint was not found.  Please install it using the method of your choice\n   https://golangci-lint.run/usage/install/#local-installation)
+	$(error golangci-lint was not found.  Please install it using the method of your choice. (https://golangci-lint.run/usage/install/#local-installation))
+endif
+
+.PHONY: snapshot
+snapshot: check-goreleaser-install
+	@goreleaser release --snapshot --rm-dist
+
+.PHONY: check-goreleaser-install
+check-goreleaser-install:
+ifeq ("$(shell command -v goreleaser)", "")
+	$(error goreleaser was not found.  Please install it using the method of your choice. (https://goreleaser.com/install))
 endif


### PR DESCRIPTION
add Goreleaser config and GH action
add new `snapshot` Make target

~Note: this does not include publishing artifacts yet.  wanted to get the basics working and up for review first.~
The CI build now triggers when a release is published (stable and pre-release) and builds and uploads archives (tarball for Linux and Mac and zip for Windows) with pre-built binaries and attached them to the release.

To test, I forked the repo into my personal GH, merged this branch, then created several releases with a minor change between each.