### PR TITLE
fix: resolve new linter warnings reported after upgrading golangci-lint to v1.46

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -362,9 +362,6 @@ func (d *Decoder) DecodePackedUint64() ([]uint64, error) {
 		if n == 0 {
 			return nil, ErrInvalidVarintData
 		}
-		if v > math.MaxUint64 {
-			return nil, ErrValueOverflow
-		}
 		nRead += uint64(n)
 		d.offset += n
 		res = append(res, v)
@@ -392,9 +389,6 @@ func (d *Decoder) DecodePackedSint32() ([]int32, error) {
 		v, n := decodeZigZag32(d.p[d.offset:])
 		if n == 0 {
 			return nil, ErrInvalidVarintData
-		}
-		if v > math.MaxInt32 {
-			return nil, ErrValueOverflow
 		}
 		nRead += uint64(n)
 		d.offset += n
@@ -424,9 +418,6 @@ func (d *Decoder) DecodePackedSint64() ([]int64, error) {
 		if n == 0 {
 			return nil, ErrInvalidVarintData
 		}
-		if v > math.MaxInt64 {
-			return nil, ErrValueOverflow
-		}
 		nRead += uint64(n)
 		d.offset += n
 		res = append(res, v)
@@ -455,9 +446,6 @@ func (d *Decoder) DecodePackedFixed32() ([]uint32, error) {
 		if n == 0 {
 			return nil, ErrInvalidVarintData
 		}
-		if v > math.MaxUint32 {
-			return nil, ErrValueOverflow
-		}
 		nRead += uint64(n)
 		d.offset += n
 		res = append(res, v)
@@ -485,9 +473,6 @@ func (d *Decoder) DecodePackedFixed64() ([]uint64, error) {
 		v, n := decodeFixed64(d.p[d.offset:])
 		if n == 0 {
 			return nil, ErrInvalidVarintData
-		}
-		if v > math.MaxUint64 {
-			return nil, ErrValueOverflow
 		}
 		nRead += uint64(n)
 		d.offset += n

--- a/json.go
+++ b/json.go
@@ -8,8 +8,8 @@ import (
 
 	gogojson "github.com/gogo/protobuf/jsonpb"
 	gogo "github.com/gogo/protobuf/proto"
-	"github.com/golang/protobuf/jsonpb"
-	protov1 "github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/jsonpb"        //nolint: staticcheck // using this deprecated package intentionally as this is a compatibility shim
+	protov1 "github.com/golang/protobuf/proto" //nolint: staticcheck // using this deprecated package intentionally as this is a compatibility shim
 	"google.golang.org/protobuf/encoding/protojson"
 	protov2 "google.golang.org/protobuf/proto"
 )


### PR DESCRIPTION
removed never-true comparisons against max int values
added `//nolint` to suppress warnings about references to `github.com/golang/protobuf`

This will also resolve the build failure in #41.