### PR TITLE
fix(codegen): correct size calculation for messages with repeated string or bytes fields

### DIFF
--- a/cmd/protoc-gen-fastmarshal/templates/fieldsnippets.tmpl
+++ b/cmd/protoc-gen-fastmarshal/templates/fieldsnippets.tmpl
@@ -12,9 +12,8 @@
     {{- end -}}
 {{- else -}}
     for _, sv := range m.{{ .GoName | getSafeFieldName }} {
-        if l = len(sv); l > 0 {
-            sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(l)) + l
-        }
+        l = len(sv)
+        sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(l)) + l
     }
 {{- end -}}
 {{ end }}
@@ -25,9 +24,8 @@
     sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(l)) + l
 {{- else -}}
     for _, bv := range m.{{ .GoName | getSafeFieldName }} {
-        if l = len(bv); l > 0 {
-            sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(l)) + l
-        }
+        l = len(bv)
+        sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(l)) + l
     }
 {{- end -}}
 {{ end }}

--- a/example/permessage/gogo/gogo_permessage_example_repeatallthethings.pb.fm.go
+++ b/example/permessage/gogo/gogo_permessage_example_repeatallthethings.pb.fm.go
@@ -24,9 +24,8 @@ func (m *RepeatAllTheThings) Size() int {
 	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
 	// TheStrings (string,repeated)
 	for _, sv := range m.TheStrings {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheBools (bool,repeated,packed)
 	if l = len(m.TheBools); l > 0 {

--- a/example/permessage/gogo/gogo_permessage_example_testevent.pb.fm.go
+++ b/example/permessage/gogo/gogo_permessage_example_testevent.pb.fm.go
@@ -31,9 +31,8 @@ func (m *TestEvent) Size() int {
 	sz += csproto.SizeOfTagKey(3) + 1
 	// Labels (string,repeated)
 	for _, sv := range m.Labels {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// Embedded (message,optional)
 	if m.Embedded != nil {

--- a/example/permessage/googlev1/googlev1_permessage_example_repeatallthethings.pb.fm.go
+++ b/example/permessage/googlev1/googlev1_permessage_example_repeatallthethings.pb.fm.go
@@ -24,9 +24,8 @@ func (m *RepeatAllTheThings) Size() int {
 	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
 	// TheStrings (string,repeated)
 	for _, sv := range m.TheStrings {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheBools (bool,repeated,packed)
 	if l = len(m.TheBools); l > 0 {

--- a/example/permessage/googlev1/googlev1_permessage_example_testevent.pb.fm.go
+++ b/example/permessage/googlev1/googlev1_permessage_example_testevent.pb.fm.go
@@ -30,9 +30,8 @@ func (m *TestEvent) Size() int {
 	sz += csproto.SizeOfTagKey(3) + 1
 	// Labels (string,repeated)
 	for _, sv := range m.Labels {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// Embedded (message,optional)
 	if m.Embedded != nil {

--- a/example/permessage/googlev2/googlev2_permessage_example_repeatallthethings.pb.fm.go
+++ b/example/permessage/googlev2/googlev2_permessage_example_repeatallthethings.pb.fm.go
@@ -24,9 +24,8 @@ func (m *RepeatAllTheThings) Size() int {
 	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
 	// TheStrings (string,repeated)
 	for _, sv := range m.TheStrings {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheBools (bool,repeated,packed)
 	if l = len(m.TheBools); l > 0 {

--- a/example/permessage/googlev2/googlev2_permessage_example_testevent.pb.fm.go
+++ b/example/permessage/googlev2/googlev2_permessage_example_testevent.pb.fm.go
@@ -30,9 +30,8 @@ func (m *TestEvent) Size() int {
 	sz += csproto.SizeOfTagKey(3) + 1
 	// Labels (string,repeated)
 	for _, sv := range m.Labels {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// Embedded (message,optional)
 	if m.Embedded != nil {

--- a/example/proto2/gogo/gogo_proto2_example.pb.fm.go
+++ b/example/proto2/gogo/gogo_proto2_example.pb.fm.go
@@ -255,9 +255,8 @@ func (m *TestEvent) Size() int {
 	}
 	// Labels (string,repeated)
 	for _, sv := range m.Labels {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// Embedded (message,required)
 	if m.Embedded != nil {
@@ -1103,9 +1102,8 @@ func (m *RepeatAllTheThings) Size() int {
 	}
 	// TheStrings (string,repeated)
 	for _, sv := range m.TheStrings {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheBools (bool,repeated)
 	if n := len(m.TheBools); n > 0 {

--- a/example/proto2/googlev1/googlev1_proto2_example.pb.fm.go
+++ b/example/proto2/googlev1/googlev1_proto2_example.pb.fm.go
@@ -255,9 +255,8 @@ func (m *TestEvent) Size() int {
 	}
 	// Labels (string,repeated)
 	for _, sv := range m.Labels {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// Embedded (message,required)
 	if m.Embedded != nil {
@@ -1103,9 +1102,8 @@ func (m *RepeatAllTheThings) Size() int {
 	}
 	// TheStrings (string,repeated)
 	for _, sv := range m.TheStrings {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheBools (bool,repeated)
 	if n := len(m.TheBools); n > 0 {

--- a/example/proto2/googlev2/googlev2_proto2_example.pb.fm.go
+++ b/example/proto2/googlev2/googlev2_proto2_example.pb.fm.go
@@ -255,9 +255,8 @@ func (m *TestEvent) Size() int {
 	}
 	// Labels (string,repeated)
 	for _, sv := range m.Labels {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// Embedded (message,required)
 	if m.Embedded != nil {
@@ -1103,9 +1102,8 @@ func (m *RepeatAllTheThings) Size() int {
 	}
 	// TheStrings (string,repeated)
 	for _, sv := range m.TheStrings {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheBools (bool,repeated)
 	if n := len(m.TheBools); n > 0 {

--- a/example/proto3/gogo/gogo_proto3_example.pb.fm.go
+++ b/example/proto3/gogo/gogo_proto3_example.pb.fm.go
@@ -31,9 +31,8 @@ func (m *TestEvent) Size() int {
 	sz += csproto.SizeOfTagKey(3) + 1
 	// Labels (string,repeated)
 	for _, sv := range m.Labels {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// Embedded (message,optional)
 	if m.Embedded != nil {
@@ -747,9 +746,8 @@ func (m *RepeatAllTheThings) Size() int {
 	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
 	// TheStrings (string,repeated)
 	for _, sv := range m.TheStrings {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheBools (bool,repeated,packed)
 	if l = len(m.TheBools); l > 0 {

--- a/example/proto3/googlev1/googlev1_proto3_example.pb.fm.go
+++ b/example/proto3/googlev1/googlev1_proto3_example.pb.fm.go
@@ -32,9 +32,8 @@ func (m *TestEvent) Size() int {
 	sz += csproto.SizeOfTagKey(3) + 1
 	// Labels (string,repeated)
 	for _, sv := range m.Labels {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// Embedded (message,optional)
 	if m.Embedded != nil {
@@ -748,9 +747,8 @@ func (m *RepeatAllTheThings) Size() int {
 	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
 	// TheStrings (string,repeated)
 	for _, sv := range m.TheStrings {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheBools (bool,repeated,packed)
 	if l = len(m.TheBools); l > 0 {

--- a/example/proto3/googlev2/googlev2_proto3_example.pb.fm.go
+++ b/example/proto3/googlev2/googlev2_proto3_example.pb.fm.go
@@ -32,9 +32,8 @@ func (m *TestEvent) Size() int {
 	sz += csproto.SizeOfTagKey(3) + 1
 	// Labels (string,repeated)
 	for _, sv := range m.Labels {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// Embedded (message,optional)
 	if m.Embedded != nil {
@@ -748,9 +747,8 @@ func (m *RepeatAllTheThings) Size() int {
 	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
 	// TheStrings (string,repeated)
 	for _, sv := range m.TheStrings {
-		if l = len(sv); l > 0 {
-			sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(sv)
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheBools (bool,repeated,packed)
 	if l = len(m.TheBools); l > 0 {


### PR DESCRIPTION
Updated code generation templates to not ignore zero-length `string` and `[]byte` fields when calculating the encoded message size

Before this change, messages that had an empty string (or empty `[]byte`) in a repeated field would generate a panic in the generated `MarshalTo(dest []byte) error` method for the message because the calculated size did not include the tag and length of 0 for those values.