### PR TITLE
fix: address perf and compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,12 +432,18 @@ goos: darwin
 goarch: amd64
 pkg: github.com/CrowdStrike/csproto/example/proto2
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-BenchmarkEncodeGogo-12                   1357027               858.9 ns/op           352 B/op          2 allocs/op
-BenchmarkCustomEncodeGogo-12             2116568               570.4 ns/op           176 B/op          1 allocs/op
-BenchmarkEncodeGoogleV1-12               1267740               934.6 ns/op           176 B/op          1 allocs/op
-BenchmarkCustomEncodeGoogleV1-12         1576399               762.9 ns/op           176 B/op          1 allocs/op
-BenchmarkEncodeGoogleV2-12               1308109               913.9 ns/op           176 B/op          1 allocs/op
-BenchmarkCustomEncodeGoogleV2-12         1641061               738.2 ns/op           176 B/op          1 allocs/op
+BenchmarkEncodeGogo-12                   1932699               597.6 ns/op           352 B/op          2 allocs/op
+BenchmarkCustomEncodeGogo-12             2458599               482.3 ns/op           176 B/op          1 allocs/op
+BenchmarkDecodeGogo-12                    622585              1887 ns/op            1376 B/op         34 allocs/op
+BenchmarkCustomDecodeGogo-12              798523              1390 ns/op            1144 B/op         27 allocs/op
+BenchmarkEncodeGoogleV1-12               1298185               925.5 ns/op           176 B/op          1 allocs/op
+BenchmarkCustomEncodeGoogleV1-12         2701975               432.4 ns/op           176 B/op          1 allocs/op
+BenchmarkDecodeGoogleV1-12                616106              1662 ns/op            1176 B/op         28 allocs/op
+BenchmarkCustomDecodeGoogleV1-12          776244              1471 ns/op            1160 B/op         26 allocs/op
+BenchmarkEncodeGoogleV2-12               1331971               911.3 ns/op           176 B/op          1 allocs/op
+BenchmarkCustomEncodeGoogleV2-12         2817786               426.1 ns/op           176 B/op          1 allocs/op
+BenchmarkDecodeGoogleV2-12                671048              1739 ns/op            1176 B/op         28 allocs/op
+BenchmarkCustomDecodeGoogleV2-12          755186              1530 ns/op            1160 B/op         26 allocs/op
 PASS
 ok      github.com/CrowdStrike/csproto/example/proto2   12.247s
 
@@ -445,27 +451,33 @@ goos: darwin
 goarch: amd64
 pkg: github.com/CrowdStrike/csproto/example/proto3
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-BenchmarkEncodeGogo-12                   3349590               352.8 ns/op           160 B/op          2 allocs/op
-BenchmarkCustomEncodeGogo-12             5543668               221.5 ns/op            80 B/op          1 allocs/op
-BenchmarkEncodeGoogleV1-12               3090246               389.5 ns/op            80 B/op          1 allocs/op
-BenchmarkCustomEncodeGoogleV1-12         5504506               215.4 ns/op            80 B/op          1 allocs/op
-BenchmarkEncodeGoogleV2-12               3222398               367.3 ns/op            80 B/op          1 allocs/op
-BenchmarkCustomEncodeGoogleV2-12         5384648               218.6 ns/op            80 B/op          1 allocs/op
+BenchmarkEncodeGogo-12                   3479755               341.0 ns/op           208 B/op          3 allocs/op
+BenchmarkCustomEncodeGogo-12             4824855               248.1 ns/op           112 B/op          2 allocs/op
+BenchmarkDecodeGogo-12                   1328734               909.9 ns/op           424 B/op         16 allocs/op
+BenchmarkCustomDecodeGogo-12             1604020               753.5 ns/op           408 B/op         15 allocs/op
+BenchmarkEncodeGoogleV1-12               2599558               450.6 ns/op            96 B/op          1 allocs/op
+BenchmarkCustomEncodeGoogleV1-12         3452514               348.4 ns/op           112 B/op          2 allocs/op
+BenchmarkDecodeGoogleV1-12                962179              1076 ns/op             440 B/op         16 allocs/op
+BenchmarkCustomDecodeGoogleV1-12         1337054               904.2 ns/op           424 B/op         15 allocs/op
+BenchmarkEncodeGoogleV2-12               2741904               433.4 ns/op            96 B/op          1 allocs/op
+BenchmarkCustomEncodeGoogleV2-12         3337425               356.1 ns/op           112 B/op          2 allocs/op
+BenchmarkDecodeGoogleV2-12               1000000              1077 ns/op             440 B/op         16 allocs/op
+BenchmarkCustomDecodeGoogleV2-12         1327365               913.4 ns/op           424 B/op         15 allocs/op
 PASS
 ok      github.com/CrowdStrike/csproto/example/proto3   9.186s
 ```
 
 As you can see in the table below, the optimized code is faster across the board.
 
-Cost      | proto2  | proto3
---------- | ------- | ------
-Gogo      | -33.6%  | -37.2%
-Google V1 | -18.4%  | -45.0%
-Google V2 | -19.2%  | -40.5%
+Cost      | proto2 (encode)  | proto3 (encode) | proto2 (decode) | proto3 (decode)
+--------- | ---------------- | --------------- | --------------- | ---------------
+Gogo      | -19.3%           | -27.2%          | -26.3%          | -17.2%
+Google V1 | -53.3%           | -22.7%          | -11.5%          | -16.0%
+Google V2 | -53.3%           | -17.8%          | -12.0%          | -15.2%
 
 ## gRPC
 
-To use with gRPC you will need to register csproto as the encoder.
+To use with gRPC you will need to register `csproto` as the encoder.
 **NOTE:** If messages do not implement `Marshaler` or `Unmarshaler` then an error will be returned.
 An example is below.
 

--- a/cmd/protoc-gen-fastmarshal/templates/fieldsnippets.tmpl
+++ b/cmd/protoc-gen-fastmarshal/templates/fieldsnippets.tmpl
@@ -7,8 +7,9 @@
         sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(l)) + l
     }
     {{- else -}}
-    l = len(m.{{ .GoName | getSafeFieldName }})
-    sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(l)) + l
+    if l = len(m.{{ .GoName | getSafeFieldName }}); l > 0 {
+        sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(l)) + l
+    }
     {{- end -}}
 {{- else -}}
     for _, sv := range m.{{ .GoName | getSafeFieldName }} {
@@ -20,8 +21,14 @@
 {{/* SizeOfBytes - calculate the encoded size of a bytes field */}}
 {{ define "SizeOfBytes" }}
 {{- if ne (.Desc.Cardinality | string) "repeated" -}}
+    {{- if eq (.Desc.Syntax | string) "proto2" -}}
     l = len(m.{{ .GoName | getSafeFieldName }})
     sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(l)) + l
+    {{- else -}}
+    if l = len(m.{{ .GoName | getSafeFieldName }}); l > 0 {
+        sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(l)) + l
+    }
+    {{- end -}}
 {{- else -}}
     for _, bv := range m.{{ .GoName | getSafeFieldName }} {
         l = len(bv)
@@ -37,7 +44,9 @@
         sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(*m.{{.GoName | getSafeFieldName}}))
     }
     {{- else -}}
-    sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(m.{{.GoName | getSafeFieldName}}))
+    if m.{{.GoName | getSafeFieldName}} != 0 {
+        sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(m.{{.GoName | getSafeFieldName}}))
+    }
     {{- end -}}
 {{- else if .Desc.IsPacked -}}
     if len(m.{{.GoName | getSafeFieldName}}) > 0 {
@@ -62,7 +71,9 @@
         sz += csproto.SizeOfTagKey({{.Desc.Number}}) + 1
     }
     {{- else -}}
-    sz += csproto.SizeOfTagKey({{.Desc.Number}}) + 1
+    if m.{{.GoName | getSafeFieldName}} {
+        sz += csproto.SizeOfTagKey({{.Desc.Number}}) + 1
+    }
     {{- end -}}
 {{- else if .Desc.IsPacked -}}
     if l = len(m.{{.GoName | getSafeFieldName}}); l > 0 {
@@ -82,7 +93,9 @@
         sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfZigZag(uint64(*m.{{.GoName | getSafeFieldName}}))
     }
     {{- else -}}
-    sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfZigZag(uint64(m.{{.GoName | getSafeFieldName}}))
+    if m.{{.GoName | getSafeFieldName}} != 0 {
+        sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfZigZag(uint64(m.{{.GoName | getSafeFieldName}}))
+    }
     {{- end -}}
 {{- else if .Desc.IsPacked -}}
     if len(m.{{.GoName | getSafeFieldName}}) > 0 {
@@ -107,7 +120,9 @@
         sz += csproto.SizeOfTagKey({{.Desc.Number}}) + {{if eq (.Desc.Kind | string) "fixed32" "sfixed32" "float"}}4{{else}}8{{end}}
     }
     {{- else -}}
-    sz += csproto.SizeOfTagKey({{.Desc.Number}}) + {{if eq (.Desc.Kind | string) "fixed32" "sfixed32" "float"}}4{{else}}8{{end}}
+    if m.{{.GoName | getSafeFieldName}} != 0 {
+        sz += csproto.SizeOfTagKey({{.Desc.Number}}) + {{if eq (.Desc.Kind | string) "fixed32" "sfixed32" "float"}}4{{else}}8{{end}}
+    }
     {{- end -}}
 {{- else if .Desc.IsPacked -}}
     if l = len(m.{{.GoName | getSafeFieldName}}); l > 0 {
@@ -306,7 +321,41 @@
     }
         {{- end -}}
     {{- else -}}
-    enc.{{$method}}({{.Desc.Number}}, m.{{.GoName | getSafeFieldName}})
+    if m.{{.GoName | getSafeFieldName }} != 0 {
+        enc.{{$method}}({{.Desc.Number}}, m.{{.GoName | getSafeFieldName}})
+    }
+    {{- end -}}
+{{- end -}}
+{{ end }}
+{{/* MarshalBool - ... */}}
+{{ define "MarshalBool" }}
+{{- $cardinality := (.Desc.Cardinality | string) -}}
+{{- if eq $cardinality "repeated" -}}
+    {{- if .Desc.IsPacked -}}
+    if len(m.{{.GoName | getSafeFieldName}}) > 0 {
+        enc.EncodePackedBool({{.Desc.Number}}, m.{{.GoName | getSafeFieldName}})
+    }
+    {{- else -}}
+    for _, val := range m.{{.GoName | getSafeFieldName}} {
+        enc.EncodeBool({{.Desc.Number}}, val)
+    }
+    {{- end -}}
+{{- else -}}
+    {{- if eq (.Desc.Syntax | string) "proto2" }}
+        {{- if eq $cardinality "required" -}}
+    if m.{{.GoName | getSafeFieldName}} == nil {
+        return fmt.Errorf("required field '{{.GoName | getSafeFieldName}}' has no value")
+    }
+    enc.EncodeBool({{.Desc.Number}}, *m.{{.GoName | getSafeFieldName}})
+        {{- else -}}
+    if m.{{.GoName | getSafeFieldName}} != nil {
+        enc.EncodeBool({{.Desc.Number}}, *m.{{.GoName | getSafeFieldName}})
+    }
+        {{- end -}}
+    {{- else -}}
+    if m.{{.GoName | getSafeFieldName}} {
+        enc.EncodeBool({{.Desc.Number}}, m.{{.GoName | getSafeFieldName}})
+    }
     {{- end -}}
 {{- end -}}
 {{ end }}
@@ -330,7 +379,9 @@
     }
         {{- end -}}
     {{- else -}}
-    enc.EncodeString({{.Desc.Number}}, m.{{.GoName | getSafeFieldName}})
+    if len(m.{{.GoName | getSafeFieldName }}) > 0 {
+        enc.EncodeString({{.Desc.Number}}, m.{{.GoName | getSafeFieldName}})
+    }
     {{- end -}}
 {{- end -}}
 {{ end }}
@@ -346,6 +397,10 @@
         return fmt.Errorf("required field '{{.GoName | getSafeFieldName}}' has no value")
     }
     enc.EncodeBytes({{.Desc.Number}}, m.{{.GoName | getSafeFieldName}})
+{{- else if eq (.Desc.Syntax | string) "proto3" -}}
+    if len(m.{{.GoName | getSafeFieldName}}) > 0 {
+        enc.EncodeBytes({{.Desc.Number}}, m.{{.GoName | getSafeFieldName}})
+    }
 {{- else -}}
     enc.EncodeBytes({{.Desc.Number}}, m.{{.GoName | getSafeFieldName}})
 {{- end -}}
@@ -421,7 +476,9 @@
     }
         {{- end -}}
     {{- else -}}
-    enc.EncodeInt32({{.Desc.Number}}, int32(m.{{.GoName | getSafeFieldName}}))
+    if m.{{.GoName | getSafeFieldName}} != 0 {
+        enc.EncodeInt32({{.Desc.Number}}, int32(m.{{.GoName | getSafeFieldName}}))
+    }
     {{- end -}}
 {{- end -}}
 {{ end }}
@@ -521,7 +578,8 @@
 {{ define "MarshalField" }}
 {{- with $field := . -}}
 {{- with $kind := ($field.Desc.Kind | string) -}}
-    {{- if eq $kind "bool" "int32" "int64" "uint32" "uint64" "sint32" "sint64" "fixed32" "float" "fixed64" "double" -}}{{template "MarshalNumber" $field}}{{- end -}}
+    {{- if eq $kind "int32" "int64" "uint32" "uint64" "sint32" "sint64" "fixed32" "float" "fixed64" "double" -}}{{template "MarshalNumber" $field}}{{- end -}}
+    {{- if eq $kind "bool" -}}{{template "MarshalBool" $field}}{{- end -}}
     {{- if eq $kind "enum" -}}{{template "MarshalEnum" $field}}{{- end -}}
     {{- if eq $kind "string" -}}{{template "MarshalString" $field}}{{- end -}}
     {{- if eq $kind "bytes" -}}{{template "MarshalBytes" $field}}{{- end -}}

--- a/cmd/protoc-gen-fastmarshal/templates/permessage.go.tmpl
+++ b/cmd/protoc-gen-fastmarshal/templates/permessage.go.tmpl
@@ -10,6 +10,7 @@ package {{ .ProtoDesc.GoPackageName }}
 import (
     "fmt"{{if and (eq $protoSyntax "proto2") (hasRequiredFields nil)}}
     "strings"{{end}}
+    "sync/atomic"
     "github.com/CrowdStrike/csproto"
     {{range (.Message | getAdditionalImports)}}{{.}}
     {{end}}
@@ -21,9 +22,19 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *{{ .Message.GoIdent.GoName }}) Size() int {
+    // nil message is always 0 bytes
     if m == nil {
         return 0
     }
+    // return cached size, if present
+{{ if eq $protoAPIVersion "v1" -}}
+    if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+{{- else -}}
+    if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+{{- end }}
+        return csz
+    }
+    // calculate and cache
     var sz, l int
     _ = l // avoid unused variable
 {{ range .Message.Fields }}
@@ -40,6 +51,12 @@ func (m *{{ .Message.GoIdent.GoName }}) Size() int {
     {{- template "SizeOfExtension" . }}
 {{ end }}
 {{- end -}}
+    // cache the size so it can be re-used in Marshal()/MarshalTo()
+{{ if eq $protoAPIVersion "v1" -}}
+    atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
+{{- else -}}
+    atomic.StoreInt32(&m.sizeCache, int32(sz))
+{{- end }}
     return sz
 }
 

--- a/cmd/protoc-gen-fastmarshal/templates/singlefile.go.tmpl
+++ b/cmd/protoc-gen-fastmarshal/templates/singlefile.go.tmpl
@@ -10,6 +10,7 @@ package {{ .ProtoDesc.GoPackageName }}
 import (
     "fmt"{{if and (eq $protoSyntax "proto2") (hasRequiredFields nil)}}
     "strings"{{end}}
+    "sync/atomic"
     "github.com/CrowdStrike/csproto"
     {{range (allMessages | getAdditionalImports)}}{{.}}
     {{end}}
@@ -24,9 +25,19 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *{{ .GoIdent.GoName }}) Size() int {
+    // nil message is always 0 bytes
     if m == nil {
         return 0
     }
+    // return cached size, if present
+{{ if eq $protoAPIVersion "v1" -}}
+    if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+{{- else -}}
+    if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+{{- end }}
+        return csz
+    }
+    // calculate and cache
     var sz, l int
     _ = l // avoid unused variable
 {{ range .Fields }}
@@ -43,6 +54,12 @@ func (m *{{ .GoIdent.GoName }}) Size() int {
     {{- template "SizeOfExtension" . }}
 {{ end }}
 {{- end -}}
+    // cache the size so it can be re-used in Marshal()/MarshalTo()
+{{ if eq $protoAPIVersion "v1" -}}
+    atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
+{{- else -}}
+    atomic.StoreInt32(&m.sizeCache, int32(sz))
+{{- end }}
     return sz
 }
 

--- a/example/permessage/gogo/gogo_permessage_example_allthemaps.pb.fm.go
+++ b/example/permessage/gogo/gogo_permessage_example_allthemaps.pb.fm.go
@@ -5,6 +5,7 @@ package gogo
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,9 +15,15 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *AllTheMaps) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -185,6 +192,8 @@ func (m *AllTheMaps) Size() int {
 		sz += csproto.SizeOfTagKey(16) + csproto.SizeOfVarint(uint64(keySize+valueSize)) + keySize + valueSize
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
 	return sz
 }
 

--- a/example/permessage/gogo/gogo_permessage_example_allthethings.pb.fm.go
+++ b/example/permessage/gogo/gogo_permessage_example_allthethings.pb.fm.go
@@ -5,6 +5,7 @@ package gogo
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,53 +15,93 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *AllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// ID (int32,optional)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	if m.ID != 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	}
 	// TheString (string,optional)
-	l = len(m.TheString)
-	sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.TheString); l > 0 {
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// TheBool (bool,optional)
-	sz += csproto.SizeOfTagKey(3) + 1
+	if m.TheBool {
+		sz += csproto.SizeOfTagKey(3) + 1
+	}
 	// TheInt32 (int32,optional)
-	sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(m.TheInt32))
+	if m.TheInt32 != 0 {
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(m.TheInt32))
+	}
 	// TheInt64 (int64,optional)
-	sz += csproto.SizeOfTagKey(5) + csproto.SizeOfVarint(uint64(m.TheInt64))
+	if m.TheInt64 != 0 {
+		sz += csproto.SizeOfTagKey(5) + csproto.SizeOfVarint(uint64(m.TheInt64))
+	}
 	// TheUInt32 (uint32,optional)
-	sz += csproto.SizeOfTagKey(6) + csproto.SizeOfVarint(uint64(m.TheUInt32))
+	if m.TheUInt32 != 0 {
+		sz += csproto.SizeOfTagKey(6) + csproto.SizeOfVarint(uint64(m.TheUInt32))
+	}
 	// TheUInt64 (uint64,optional)
-	sz += csproto.SizeOfTagKey(7) + csproto.SizeOfVarint(uint64(m.TheUInt64))
+	if m.TheUInt64 != 0 {
+		sz += csproto.SizeOfTagKey(7) + csproto.SizeOfVarint(uint64(m.TheUInt64))
+	}
 	// TheSInt32 (sint32,optional)
-	sz += csproto.SizeOfTagKey(8) + csproto.SizeOfZigZag(uint64(m.TheSInt32))
+	if m.TheSInt32 != 0 {
+		sz += csproto.SizeOfTagKey(8) + csproto.SizeOfZigZag(uint64(m.TheSInt32))
+	}
 	// TheSInt64 (sint64,optional)
-	sz += csproto.SizeOfTagKey(9) + csproto.SizeOfZigZag(uint64(m.TheSInt64))
+	if m.TheSInt64 != 0 {
+		sz += csproto.SizeOfTagKey(9) + csproto.SizeOfZigZag(uint64(m.TheSInt64))
+	}
 	// TheFixed32 (fixed32,optional)
-	sz += csproto.SizeOfTagKey(10) + 4
+	if m.TheFixed32 != 0 {
+		sz += csproto.SizeOfTagKey(10) + 4
+	}
 	// TheFixed64 (fixed64,optional)
-	sz += csproto.SizeOfTagKey(11) + 8
+	if m.TheFixed64 != 0 {
+		sz += csproto.SizeOfTagKey(11) + 8
+	}
 	// TheSFixed32 (sfixed32,optional)
-	sz += csproto.SizeOfTagKey(12) + 4
+	if m.TheSFixed32 != 0 {
+		sz += csproto.SizeOfTagKey(12) + 4
+	}
 	// TheSFixed64 (sfixed64,optional)
-	sz += csproto.SizeOfTagKey(13) + 8
+	if m.TheSFixed64 != 0 {
+		sz += csproto.SizeOfTagKey(13) + 8
+	}
 	// TheFloat (float,optional)
-	sz += csproto.SizeOfTagKey(14) + 4
+	if m.TheFloat != 0 {
+		sz += csproto.SizeOfTagKey(14) + 4
+	}
 	// TheDouble (double,optional)
-	sz += csproto.SizeOfTagKey(15) + 8
+	if m.TheDouble != 0 {
+		sz += csproto.SizeOfTagKey(15) + 8
+	}
 	// TheEventType (enum,optional)
-	sz += csproto.SizeOfTagKey(16) + csproto.SizeOfVarint(uint64(m.TheEventType))
+	if m.TheEventType != 0 {
+		sz += csproto.SizeOfTagKey(16) + csproto.SizeOfVarint(uint64(m.TheEventType))
+	}
 	// TheBytes (bytes,optional)
-	l = len(m.TheBytes)
-	sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.TheBytes); l > 0 {
+		sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// TheMessage (message,optional)
 	if m.TheMessage != nil {
 		l = csproto.Size(m.TheMessage)
 		sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
 	return sz
 }
 
@@ -87,39 +128,69 @@ func (m *AllTheThings) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// ID (1,int32,optional)
-	enc.EncodeInt32(1, m.ID)
+	if m.ID != 0 {
+		enc.EncodeInt32(1, m.ID)
+	}
 	// TheString (2,string,optional)
-	enc.EncodeString(2, m.TheString)
+	if len(m.TheString) > 0 {
+		enc.EncodeString(2, m.TheString)
+	}
 	// TheBool (3,bool,optional)
-	enc.EncodeBool(3, m.TheBool)
+	if m.TheBool {
+		enc.EncodeBool(3, m.TheBool)
+	}
 	// TheInt32 (4,int32,optional)
-	enc.EncodeInt32(4, m.TheInt32)
+	if m.TheInt32 != 0 {
+		enc.EncodeInt32(4, m.TheInt32)
+	}
 	// TheInt64 (5,int64,optional)
-	enc.EncodeInt64(5, m.TheInt64)
+	if m.TheInt64 != 0 {
+		enc.EncodeInt64(5, m.TheInt64)
+	}
 	// TheUInt32 (6,uint32,optional)
-	enc.EncodeUInt32(6, m.TheUInt32)
+	if m.TheUInt32 != 0 {
+		enc.EncodeUInt32(6, m.TheUInt32)
+	}
 	// TheUInt64 (7,uint64,optional)
-	enc.EncodeUInt64(7, m.TheUInt64)
+	if m.TheUInt64 != 0 {
+		enc.EncodeUInt64(7, m.TheUInt64)
+	}
 	// TheSInt32 (8,sint32,optional)
-	enc.EncodeSInt32(8, m.TheSInt32)
+	if m.TheSInt32 != 0 {
+		enc.EncodeSInt32(8, m.TheSInt32)
+	}
 	// TheSInt64 (9,sint64,optional)
-	enc.EncodeSInt64(9, m.TheSInt64)
+	if m.TheSInt64 != 0 {
+		enc.EncodeSInt64(9, m.TheSInt64)
+	}
 	// TheFixed32 (10,fixed32,optional)
-	enc.EncodeFixed32(10, m.TheFixed32)
+	if m.TheFixed32 != 0 {
+		enc.EncodeFixed32(10, m.TheFixed32)
+	}
 	// TheFixed64 (11,fixed64,optional)
-	enc.EncodeFixed64(11, m.TheFixed64)
+	if m.TheFixed64 != 0 {
+		enc.EncodeFixed64(11, m.TheFixed64)
+	}
 	// TheSFixed32 (12,sfixed32,optional)
 	enc.EncodeFixed32(12, uint32(m.TheSFixed32))
 	// TheSFixed64 (13,sfixed64,optional)
 	enc.EncodeFixed64(13, uint64(m.TheSFixed64))
 	// TheFloat (14,float,optional)
-	enc.EncodeFloat32(14, m.TheFloat)
+	if m.TheFloat != 0 {
+		enc.EncodeFloat32(14, m.TheFloat)
+	}
 	// TheDouble (15,double,optional)
-	enc.EncodeFloat64(15, m.TheDouble)
+	if m.TheDouble != 0 {
+		enc.EncodeFloat64(15, m.TheDouble)
+	}
 	// TheEventType (16,enum,optional)
-	enc.EncodeInt32(16, int32(m.TheEventType))
+	if m.TheEventType != 0 {
+		enc.EncodeInt32(16, int32(m.TheEventType))
+	}
 	// TheBytes (17,bytes,optional)
-	enc.EncodeBytes(17, m.TheBytes)
+	if len(m.TheBytes) > 0 {
+		enc.EncodeBytes(17, m.TheBytes)
+	}
 	// TheMessage (18,message,optional)
 	if m.TheMessage != nil {
 		if err = enc.EncodeNested(18, m.TheMessage); err != nil {

--- a/example/permessage/gogo/gogo_permessage_example_embeddedevent.pb.fm.go
+++ b/example/permessage/gogo/gogo_permessage_example_embeddedevent.pb.fm.go
@@ -5,6 +5,7 @@ package gogo
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,17 +15,26 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *EmbeddedEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// ID (int32,optional)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	if m.ID != 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	}
 	// Stuff (string,optional)
-	l = len(m.Stuff)
-	sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Stuff); l > 0 {
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// FavoriteNumbers (int32,repeated,packed)
 	if len(m.FavoriteNumbers) > 0 {
 		sz += csproto.SizeOfTagKey(3)
@@ -36,12 +46,15 @@ func (m *EmbeddedEvent) Size() int {
 	}
 	// RandomThings (bytes,repeated)
 	for _, bv := range m.RandomThings {
-		if l = len(bv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(bv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// Size (int32,optional)
-	sz += csproto.SizeOfTagKey(5) + csproto.SizeOfVarint(uint64(m.Size_))
+	if m.Size_ != 0 {
+		sz += csproto.SizeOfTagKey(5) + csproto.SizeOfVarint(uint64(m.Size_))
+	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
 	return sz
 }
 
@@ -68,9 +81,13 @@ func (m *EmbeddedEvent) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// ID (1,int32,optional)
-	enc.EncodeInt32(1, m.ID)
+	if m.ID != 0 {
+		enc.EncodeInt32(1, m.ID)
+	}
 	// Stuff (2,string,optional)
-	enc.EncodeString(2, m.Stuff)
+	if len(m.Stuff) > 0 {
+		enc.EncodeString(2, m.Stuff)
+	}
 	// FavoriteNumbers (3,int32,repeated,packed)
 	if len(m.FavoriteNumbers) > 0 {
 		enc.EncodePackedInt32(3, m.FavoriteNumbers)
@@ -80,7 +97,9 @@ func (m *EmbeddedEvent) MarshalTo(dest []byte) error {
 		enc.EncodeBytes(4, val)
 	}
 	// Size (5,int32,optional)
-	enc.EncodeInt32(5, m.Size_)
+	if m.Size_ != 0 {
+		enc.EncodeInt32(5, m.Size_)
+	}
 	return nil
 }
 

--- a/example/permessage/gogo/gogo_permessage_example_nestedmsg.pb.fm.go
+++ b/example/permessage/gogo/gogo_permessage_example_nestedmsg.pb.fm.go
@@ -5,6 +5,7 @@ package gogo
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,15 +15,24 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent_NestedMsg) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// Details (string,optional)
-	l = len(m.Details)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Details); l > 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
 	return sz
 }
 
@@ -49,7 +59,9 @@ func (m *TestEvent_NestedMsg) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// Details (1,string,optional)
-	enc.EncodeString(1, m.Details)
+	if len(m.Details) > 0 {
+		enc.EncodeString(1, m.Details)
+	}
 	return nil
 }
 

--- a/example/permessage/googlev1/googlev1_permessage_example_allthemaps.pb.fm.go
+++ b/example/permessage/googlev1/googlev1_permessage_example_allthemaps.pb.fm.go
@@ -5,6 +5,7 @@ package googlev1
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,9 +15,15 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *AllTheMaps) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -185,6 +192,8 @@ func (m *AllTheMaps) Size() int {
 		sz += csproto.SizeOfTagKey(16) + csproto.SizeOfVarint(uint64(keySize+valueSize)) + keySize + valueSize
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 

--- a/example/permessage/googlev1/googlev1_permessage_example_allthethings.pb.fm.go
+++ b/example/permessage/googlev1/googlev1_permessage_example_allthethings.pb.fm.go
@@ -5,6 +5,7 @@ package googlev1
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,53 +15,93 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *AllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// ID (int32,optional)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	if m.ID != 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	}
 	// TheString (string,optional)
-	l = len(m.TheString)
-	sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.TheString); l > 0 {
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// TheBool (bool,optional)
-	sz += csproto.SizeOfTagKey(3) + 1
+	if m.TheBool {
+		sz += csproto.SizeOfTagKey(3) + 1
+	}
 	// TheInt32 (int32,optional)
-	sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(m.TheInt32))
+	if m.TheInt32 != 0 {
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(m.TheInt32))
+	}
 	// TheInt64 (int64,optional)
-	sz += csproto.SizeOfTagKey(5) + csproto.SizeOfVarint(uint64(m.TheInt64))
+	if m.TheInt64 != 0 {
+		sz += csproto.SizeOfTagKey(5) + csproto.SizeOfVarint(uint64(m.TheInt64))
+	}
 	// TheUInt32 (uint32,optional)
-	sz += csproto.SizeOfTagKey(6) + csproto.SizeOfVarint(uint64(m.TheUInt32))
+	if m.TheUInt32 != 0 {
+		sz += csproto.SizeOfTagKey(6) + csproto.SizeOfVarint(uint64(m.TheUInt32))
+	}
 	// TheUInt64 (uint64,optional)
-	sz += csproto.SizeOfTagKey(7) + csproto.SizeOfVarint(uint64(m.TheUInt64))
+	if m.TheUInt64 != 0 {
+		sz += csproto.SizeOfTagKey(7) + csproto.SizeOfVarint(uint64(m.TheUInt64))
+	}
 	// TheSInt32 (sint32,optional)
-	sz += csproto.SizeOfTagKey(8) + csproto.SizeOfZigZag(uint64(m.TheSInt32))
+	if m.TheSInt32 != 0 {
+		sz += csproto.SizeOfTagKey(8) + csproto.SizeOfZigZag(uint64(m.TheSInt32))
+	}
 	// TheSInt64 (sint64,optional)
-	sz += csproto.SizeOfTagKey(9) + csproto.SizeOfZigZag(uint64(m.TheSInt64))
+	if m.TheSInt64 != 0 {
+		sz += csproto.SizeOfTagKey(9) + csproto.SizeOfZigZag(uint64(m.TheSInt64))
+	}
 	// TheFixed32 (fixed32,optional)
-	sz += csproto.SizeOfTagKey(10) + 4
+	if m.TheFixed32 != 0 {
+		sz += csproto.SizeOfTagKey(10) + 4
+	}
 	// TheFixed64 (fixed64,optional)
-	sz += csproto.SizeOfTagKey(11) + 8
+	if m.TheFixed64 != 0 {
+		sz += csproto.SizeOfTagKey(11) + 8
+	}
 	// TheSFixed32 (sfixed32,optional)
-	sz += csproto.SizeOfTagKey(12) + 4
+	if m.TheSFixed32 != 0 {
+		sz += csproto.SizeOfTagKey(12) + 4
+	}
 	// TheSFixed64 (sfixed64,optional)
-	sz += csproto.SizeOfTagKey(13) + 8
+	if m.TheSFixed64 != 0 {
+		sz += csproto.SizeOfTagKey(13) + 8
+	}
 	// TheFloat (float,optional)
-	sz += csproto.SizeOfTagKey(14) + 4
+	if m.TheFloat != 0 {
+		sz += csproto.SizeOfTagKey(14) + 4
+	}
 	// TheDouble (double,optional)
-	sz += csproto.SizeOfTagKey(15) + 8
+	if m.TheDouble != 0 {
+		sz += csproto.SizeOfTagKey(15) + 8
+	}
 	// TheEventType (enum,optional)
-	sz += csproto.SizeOfTagKey(16) + csproto.SizeOfVarint(uint64(m.TheEventType))
+	if m.TheEventType != 0 {
+		sz += csproto.SizeOfTagKey(16) + csproto.SizeOfVarint(uint64(m.TheEventType))
+	}
 	// TheBytes (bytes,optional)
-	l = len(m.TheBytes)
-	sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.TheBytes); l > 0 {
+		sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// TheMessage (message,optional)
 	if m.TheMessage != nil {
 		l = csproto.Size(m.TheMessage)
 		sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -87,39 +128,69 @@ func (m *AllTheThings) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// ID (1,int32,optional)
-	enc.EncodeInt32(1, m.ID)
+	if m.ID != 0 {
+		enc.EncodeInt32(1, m.ID)
+	}
 	// TheString (2,string,optional)
-	enc.EncodeString(2, m.TheString)
+	if len(m.TheString) > 0 {
+		enc.EncodeString(2, m.TheString)
+	}
 	// TheBool (3,bool,optional)
-	enc.EncodeBool(3, m.TheBool)
+	if m.TheBool {
+		enc.EncodeBool(3, m.TheBool)
+	}
 	// TheInt32 (4,int32,optional)
-	enc.EncodeInt32(4, m.TheInt32)
+	if m.TheInt32 != 0 {
+		enc.EncodeInt32(4, m.TheInt32)
+	}
 	// TheInt64 (5,int64,optional)
-	enc.EncodeInt64(5, m.TheInt64)
+	if m.TheInt64 != 0 {
+		enc.EncodeInt64(5, m.TheInt64)
+	}
 	// TheUInt32 (6,uint32,optional)
-	enc.EncodeUInt32(6, m.TheUInt32)
+	if m.TheUInt32 != 0 {
+		enc.EncodeUInt32(6, m.TheUInt32)
+	}
 	// TheUInt64 (7,uint64,optional)
-	enc.EncodeUInt64(7, m.TheUInt64)
+	if m.TheUInt64 != 0 {
+		enc.EncodeUInt64(7, m.TheUInt64)
+	}
 	// TheSInt32 (8,sint32,optional)
-	enc.EncodeSInt32(8, m.TheSInt32)
+	if m.TheSInt32 != 0 {
+		enc.EncodeSInt32(8, m.TheSInt32)
+	}
 	// TheSInt64 (9,sint64,optional)
-	enc.EncodeSInt64(9, m.TheSInt64)
+	if m.TheSInt64 != 0 {
+		enc.EncodeSInt64(9, m.TheSInt64)
+	}
 	// TheFixed32 (10,fixed32,optional)
-	enc.EncodeFixed32(10, m.TheFixed32)
+	if m.TheFixed32 != 0 {
+		enc.EncodeFixed32(10, m.TheFixed32)
+	}
 	// TheFixed64 (11,fixed64,optional)
-	enc.EncodeFixed64(11, m.TheFixed64)
+	if m.TheFixed64 != 0 {
+		enc.EncodeFixed64(11, m.TheFixed64)
+	}
 	// TheSFixed32 (12,sfixed32,optional)
 	enc.EncodeFixed32(12, uint32(m.TheSFixed32))
 	// TheSFixed64 (13,sfixed64,optional)
 	enc.EncodeFixed64(13, uint64(m.TheSFixed64))
 	// TheFloat (14,float,optional)
-	enc.EncodeFloat32(14, m.TheFloat)
+	if m.TheFloat != 0 {
+		enc.EncodeFloat32(14, m.TheFloat)
+	}
 	// TheDouble (15,double,optional)
-	enc.EncodeFloat64(15, m.TheDouble)
+	if m.TheDouble != 0 {
+		enc.EncodeFloat64(15, m.TheDouble)
+	}
 	// TheEventType (16,enum,optional)
-	enc.EncodeInt32(16, int32(m.TheEventType))
+	if m.TheEventType != 0 {
+		enc.EncodeInt32(16, int32(m.TheEventType))
+	}
 	// TheBytes (17,bytes,optional)
-	enc.EncodeBytes(17, m.TheBytes)
+	if len(m.TheBytes) > 0 {
+		enc.EncodeBytes(17, m.TheBytes)
+	}
 	// TheMessage (18,message,optional)
 	if m.TheMessage != nil {
 		if err = enc.EncodeNested(18, m.TheMessage); err != nil {

--- a/example/permessage/googlev1/googlev1_permessage_example_nestedmsg.pb.fm.go
+++ b/example/permessage/googlev1/googlev1_permessage_example_nestedmsg.pb.fm.go
@@ -5,6 +5,7 @@ package googlev1
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,15 +15,24 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent_NestedMsg) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// Details (string,optional)
-	l = len(m.Details)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Details); l > 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -49,7 +59,9 @@ func (m *TestEvent_NestedMsg) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// Details (1,string,optional)
-	enc.EncodeString(1, m.Details)
+	if len(m.Details) > 0 {
+		enc.EncodeString(1, m.Details)
+	}
 	return nil
 }
 

--- a/example/permessage/googlev1/googlev1_permessage_example_repeatallthethings.pb.fm.go
+++ b/example/permessage/googlev1/googlev1_permessage_example_repeatallthethings.pb.fm.go
@@ -5,6 +5,7 @@ package googlev1
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,14 +15,22 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *RepeatAllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// ID (int32,optional)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	if m.ID != 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	}
 	// TheStrings (string,repeated)
 	for _, sv := range m.TheStrings {
 		l = len(sv)
@@ -120,9 +129,8 @@ func (m *RepeatAllTheThings) Size() int {
 	}
 	// TheBytes (bytes,repeated)
 	for _, bv := range m.TheBytes {
-		if l = len(bv); l > 0 {
-			sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(bv)
+		sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheMessages (message,repeated)
 	for _, val := range m.TheMessages {
@@ -130,6 +138,8 @@ func (m *RepeatAllTheThings) Size() int {
 			sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 		}
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -156,7 +166,9 @@ func (m *RepeatAllTheThings) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// ID (1,int32,optional)
-	enc.EncodeInt32(1, m.ID)
+	if m.ID != 0 {
+		enc.EncodeInt32(1, m.ID)
+	}
 	// TheStrings (2,string,repeated)
 	for _, val := range m.TheStrings {
 		enc.EncodeString(2, val)

--- a/example/permessage/googlev1/googlev1_permessage_example_testevent.pb.fm.go
+++ b/example/permessage/googlev1/googlev1_permessage_example_testevent.pb.fm.go
@@ -5,6 +5,7 @@ package googlev1
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,20 +15,30 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// Name (string,optional)
-	l = len(m.Name)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Name); l > 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// Info (string,optional)
-	l = len(m.Info)
-	sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Info); l > 0 {
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// IsAwesome (bool,optional)
-	sz += csproto.SizeOfTagKey(3) + 1
+	if m.IsAwesome {
+		sz += csproto.SizeOfTagKey(3) + 1
+	}
 	// Labels (string,repeated)
 	for _, sv := range m.Labels {
 		l = len(sv)
@@ -58,6 +69,8 @@ func (m *TestEvent) Size() int {
 		}
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -84,11 +97,17 @@ func (m *TestEvent) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// Name (1,string,optional)
-	enc.EncodeString(1, m.Name)
+	if len(m.Name) > 0 {
+		enc.EncodeString(1, m.Name)
+	}
 	// Info (2,string,optional)
-	enc.EncodeString(2, m.Info)
+	if len(m.Info) > 0 {
+		enc.EncodeString(2, m.Info)
+	}
 	// IsAwesome (3,bool,optional)
-	enc.EncodeBool(3, m.IsAwesome)
+	if m.IsAwesome {
+		enc.EncodeBool(3, m.IsAwesome)
+	}
 	// Labels (4,string,repeated)
 	for _, val := range m.Labels {
 		enc.EncodeString(4, val)

--- a/example/permessage/googlev2/googlev2_permessage_example_allthemaps.pb.fm.go
+++ b/example/permessage/googlev2/googlev2_permessage_example_allthemaps.pb.fm.go
@@ -5,6 +5,7 @@ package googlev2
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,9 +15,15 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *AllTheMaps) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -185,6 +192,8 @@ func (m *AllTheMaps) Size() int {
 		sz += csproto.SizeOfTagKey(16) + csproto.SizeOfVarint(uint64(keySize+valueSize)) + keySize + valueSize
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 

--- a/example/permessage/googlev2/googlev2_permessage_example_allthethings.pb.fm.go
+++ b/example/permessage/googlev2/googlev2_permessage_example_allthethings.pb.fm.go
@@ -5,6 +5,7 @@ package googlev2
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,53 +15,93 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *AllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// ID (int32,optional)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	if m.ID != 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	}
 	// TheString (string,optional)
-	l = len(m.TheString)
-	sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.TheString); l > 0 {
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// TheBool (bool,optional)
-	sz += csproto.SizeOfTagKey(3) + 1
+	if m.TheBool {
+		sz += csproto.SizeOfTagKey(3) + 1
+	}
 	// TheInt32 (int32,optional)
-	sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(m.TheInt32))
+	if m.TheInt32 != 0 {
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(m.TheInt32))
+	}
 	// TheInt64 (int64,optional)
-	sz += csproto.SizeOfTagKey(5) + csproto.SizeOfVarint(uint64(m.TheInt64))
+	if m.TheInt64 != 0 {
+		sz += csproto.SizeOfTagKey(5) + csproto.SizeOfVarint(uint64(m.TheInt64))
+	}
 	// TheUInt32 (uint32,optional)
-	sz += csproto.SizeOfTagKey(6) + csproto.SizeOfVarint(uint64(m.TheUInt32))
+	if m.TheUInt32 != 0 {
+		sz += csproto.SizeOfTagKey(6) + csproto.SizeOfVarint(uint64(m.TheUInt32))
+	}
 	// TheUInt64 (uint64,optional)
-	sz += csproto.SizeOfTagKey(7) + csproto.SizeOfVarint(uint64(m.TheUInt64))
+	if m.TheUInt64 != 0 {
+		sz += csproto.SizeOfTagKey(7) + csproto.SizeOfVarint(uint64(m.TheUInt64))
+	}
 	// TheSInt32 (sint32,optional)
-	sz += csproto.SizeOfTagKey(8) + csproto.SizeOfZigZag(uint64(m.TheSInt32))
+	if m.TheSInt32 != 0 {
+		sz += csproto.SizeOfTagKey(8) + csproto.SizeOfZigZag(uint64(m.TheSInt32))
+	}
 	// TheSInt64 (sint64,optional)
-	sz += csproto.SizeOfTagKey(9) + csproto.SizeOfZigZag(uint64(m.TheSInt64))
+	if m.TheSInt64 != 0 {
+		sz += csproto.SizeOfTagKey(9) + csproto.SizeOfZigZag(uint64(m.TheSInt64))
+	}
 	// TheFixed32 (fixed32,optional)
-	sz += csproto.SizeOfTagKey(10) + 4
+	if m.TheFixed32 != 0 {
+		sz += csproto.SizeOfTagKey(10) + 4
+	}
 	// TheFixed64 (fixed64,optional)
-	sz += csproto.SizeOfTagKey(11) + 8
+	if m.TheFixed64 != 0 {
+		sz += csproto.SizeOfTagKey(11) + 8
+	}
 	// TheSFixed32 (sfixed32,optional)
-	sz += csproto.SizeOfTagKey(12) + 4
+	if m.TheSFixed32 != 0 {
+		sz += csproto.SizeOfTagKey(12) + 4
+	}
 	// TheSFixed64 (sfixed64,optional)
-	sz += csproto.SizeOfTagKey(13) + 8
+	if m.TheSFixed64 != 0 {
+		sz += csproto.SizeOfTagKey(13) + 8
+	}
 	// TheFloat (float,optional)
-	sz += csproto.SizeOfTagKey(14) + 4
+	if m.TheFloat != 0 {
+		sz += csproto.SizeOfTagKey(14) + 4
+	}
 	// TheDouble (double,optional)
-	sz += csproto.SizeOfTagKey(15) + 8
+	if m.TheDouble != 0 {
+		sz += csproto.SizeOfTagKey(15) + 8
+	}
 	// TheEventType (enum,optional)
-	sz += csproto.SizeOfTagKey(16) + csproto.SizeOfVarint(uint64(m.TheEventType))
+	if m.TheEventType != 0 {
+		sz += csproto.SizeOfTagKey(16) + csproto.SizeOfVarint(uint64(m.TheEventType))
+	}
 	// TheBytes (bytes,optional)
-	l = len(m.TheBytes)
-	sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.TheBytes); l > 0 {
+		sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// TheMessage (message,optional)
 	if m.TheMessage != nil {
 		l = csproto.Size(m.TheMessage)
 		sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -87,39 +128,69 @@ func (m *AllTheThings) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// ID (1,int32,optional)
-	enc.EncodeInt32(1, m.ID)
+	if m.ID != 0 {
+		enc.EncodeInt32(1, m.ID)
+	}
 	// TheString (2,string,optional)
-	enc.EncodeString(2, m.TheString)
+	if len(m.TheString) > 0 {
+		enc.EncodeString(2, m.TheString)
+	}
 	// TheBool (3,bool,optional)
-	enc.EncodeBool(3, m.TheBool)
+	if m.TheBool {
+		enc.EncodeBool(3, m.TheBool)
+	}
 	// TheInt32 (4,int32,optional)
-	enc.EncodeInt32(4, m.TheInt32)
+	if m.TheInt32 != 0 {
+		enc.EncodeInt32(4, m.TheInt32)
+	}
 	// TheInt64 (5,int64,optional)
-	enc.EncodeInt64(5, m.TheInt64)
+	if m.TheInt64 != 0 {
+		enc.EncodeInt64(5, m.TheInt64)
+	}
 	// TheUInt32 (6,uint32,optional)
-	enc.EncodeUInt32(6, m.TheUInt32)
+	if m.TheUInt32 != 0 {
+		enc.EncodeUInt32(6, m.TheUInt32)
+	}
 	// TheUInt64 (7,uint64,optional)
-	enc.EncodeUInt64(7, m.TheUInt64)
+	if m.TheUInt64 != 0 {
+		enc.EncodeUInt64(7, m.TheUInt64)
+	}
 	// TheSInt32 (8,sint32,optional)
-	enc.EncodeSInt32(8, m.TheSInt32)
+	if m.TheSInt32 != 0 {
+		enc.EncodeSInt32(8, m.TheSInt32)
+	}
 	// TheSInt64 (9,sint64,optional)
-	enc.EncodeSInt64(9, m.TheSInt64)
+	if m.TheSInt64 != 0 {
+		enc.EncodeSInt64(9, m.TheSInt64)
+	}
 	// TheFixed32 (10,fixed32,optional)
-	enc.EncodeFixed32(10, m.TheFixed32)
+	if m.TheFixed32 != 0 {
+		enc.EncodeFixed32(10, m.TheFixed32)
+	}
 	// TheFixed64 (11,fixed64,optional)
-	enc.EncodeFixed64(11, m.TheFixed64)
+	if m.TheFixed64 != 0 {
+		enc.EncodeFixed64(11, m.TheFixed64)
+	}
 	// TheSFixed32 (12,sfixed32,optional)
 	enc.EncodeFixed32(12, uint32(m.TheSFixed32))
 	// TheSFixed64 (13,sfixed64,optional)
 	enc.EncodeFixed64(13, uint64(m.TheSFixed64))
 	// TheFloat (14,float,optional)
-	enc.EncodeFloat32(14, m.TheFloat)
+	if m.TheFloat != 0 {
+		enc.EncodeFloat32(14, m.TheFloat)
+	}
 	// TheDouble (15,double,optional)
-	enc.EncodeFloat64(15, m.TheDouble)
+	if m.TheDouble != 0 {
+		enc.EncodeFloat64(15, m.TheDouble)
+	}
 	// TheEventType (16,enum,optional)
-	enc.EncodeInt32(16, int32(m.TheEventType))
+	if m.TheEventType != 0 {
+		enc.EncodeInt32(16, int32(m.TheEventType))
+	}
 	// TheBytes (17,bytes,optional)
-	enc.EncodeBytes(17, m.TheBytes)
+	if len(m.TheBytes) > 0 {
+		enc.EncodeBytes(17, m.TheBytes)
+	}
 	// TheMessage (18,message,optional)
 	if m.TheMessage != nil {
 		if err = enc.EncodeNested(18, m.TheMessage); err != nil {

--- a/example/permessage/googlev2/googlev2_permessage_example_embeddedevent.pb.fm.go
+++ b/example/permessage/googlev2/googlev2_permessage_example_embeddedevent.pb.fm.go
@@ -5,6 +5,7 @@ package googlev2
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,17 +15,26 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *EmbeddedEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// ID (int32,optional)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	if m.ID != 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	}
 	// Stuff (string,optional)
-	l = len(m.Stuff)
-	sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Stuff); l > 0 {
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// FavoriteNumbers (int32,repeated,packed)
 	if len(m.FavoriteNumbers) > 0 {
 		sz += csproto.SizeOfTagKey(3)
@@ -36,10 +46,11 @@ func (m *EmbeddedEvent) Size() int {
 	}
 	// RandomThings (bytes,repeated)
 	for _, bv := range m.RandomThings {
-		if l = len(bv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(bv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -66,9 +77,13 @@ func (m *EmbeddedEvent) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// ID (1,int32,optional)
-	enc.EncodeInt32(1, m.ID)
+	if m.ID != 0 {
+		enc.EncodeInt32(1, m.ID)
+	}
 	// Stuff (2,string,optional)
-	enc.EncodeString(2, m.Stuff)
+	if len(m.Stuff) > 0 {
+		enc.EncodeString(2, m.Stuff)
+	}
 	// FavoriteNumbers (3,int32,repeated,packed)
 	if len(m.FavoriteNumbers) > 0 {
 		enc.EncodePackedInt32(3, m.FavoriteNumbers)

--- a/example/permessage/googlev2/googlev2_permessage_example_repeatallthethings.pb.fm.go
+++ b/example/permessage/googlev2/googlev2_permessage_example_repeatallthethings.pb.fm.go
@@ -5,6 +5,7 @@ package googlev2
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,14 +15,22 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *RepeatAllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// ID (int32,optional)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	if m.ID != 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	}
 	// TheStrings (string,repeated)
 	for _, sv := range m.TheStrings {
 		l = len(sv)
@@ -120,9 +129,8 @@ func (m *RepeatAllTheThings) Size() int {
 	}
 	// TheBytes (bytes,repeated)
 	for _, bv := range m.TheBytes {
-		if l = len(bv); l > 0 {
-			sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(bv)
+		sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheMessages (message,repeated)
 	for _, val := range m.TheMessages {
@@ -130,6 +138,8 @@ func (m *RepeatAllTheThings) Size() int {
 			sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 		}
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -156,7 +166,9 @@ func (m *RepeatAllTheThings) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// ID (1,int32,optional)
-	enc.EncodeInt32(1, m.ID)
+	if m.ID != 0 {
+		enc.EncodeInt32(1, m.ID)
+	}
 	// TheStrings (2,string,repeated)
 	for _, val := range m.TheStrings {
 		enc.EncodeString(2, val)

--- a/example/permessage/googlev2/googlev2_permessage_example_testevent.pb.fm.go
+++ b/example/permessage/googlev2/googlev2_permessage_example_testevent.pb.fm.go
@@ -5,6 +5,7 @@ package googlev2
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -14,20 +15,30 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// Name (string,optional)
-	l = len(m.Name)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Name); l > 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// Info (string,optional)
-	l = len(m.Info)
-	sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Info); l > 0 {
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// IsAwesome (bool,optional)
-	sz += csproto.SizeOfTagKey(3) + 1
+	if m.IsAwesome {
+		sz += csproto.SizeOfTagKey(3) + 1
+	}
 	// Labels (string,repeated)
 	for _, sv := range m.Labels {
 		l = len(sv)
@@ -58,6 +69,8 @@ func (m *TestEvent) Size() int {
 		}
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -84,11 +97,17 @@ func (m *TestEvent) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// Name (1,string,optional)
-	enc.EncodeString(1, m.Name)
+	if len(m.Name) > 0 {
+		enc.EncodeString(1, m.Name)
+	}
 	// Info (2,string,optional)
-	enc.EncodeString(2, m.Info)
+	if len(m.Info) > 0 {
+		enc.EncodeString(2, m.Info)
+	}
 	// IsAwesome (3,bool,optional)
-	enc.EncodeBool(3, m.IsAwesome)
+	if m.IsAwesome {
+		enc.EncodeBool(3, m.IsAwesome)
+	}
 	// Labels (4,string,repeated)
 	for _, val := range m.Labels {
 		enc.EncodeString(4, val)

--- a/example/proto2/gogo/gogo_proto2_example.pb.fm.go
+++ b/example/proto2/gogo/gogo_proto2_example.pb.fm.go
@@ -6,6 +6,7 @@ package gogo
 import (
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -15,9 +16,15 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *BaseEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -54,6 +61,8 @@ func (m *BaseEvent) Size() int {
 		sz += csproto.SizeOfTagKey(101) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
 	return sz
 }
 
@@ -256,9 +265,15 @@ func (m *BaseEvent) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -306,6 +321,8 @@ func (m *TestEvent) Size() int {
 		}
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
 	return sz
 }
 
@@ -527,9 +544,15 @@ func (m *TestEvent) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *EmbeddedEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -551,6 +574,8 @@ func (m *EmbeddedEvent) Size() int {
 		l = len(bv)
 		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
 	return sz
 }
 
@@ -702,9 +727,15 @@ func (m *EmbeddedEvent) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *AllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -781,6 +812,8 @@ func (m *AllTheThings) Size() int {
 		l = csproto.Size(m.TheMessage)
 		sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
 	return sz
 }
 
@@ -1112,9 +1145,15 @@ func (m *AllTheThings) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *RepeatAllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -1194,6 +1233,8 @@ func (m *RepeatAllTheThings) Size() int {
 			sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 		}
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
 	return sz
 }
 
@@ -1622,9 +1663,15 @@ func (m *RepeatAllTheThings) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *AllOptionalFields) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -1643,6 +1690,8 @@ func (m *AllOptionalFields) Size() int {
 		sz += csproto.SizeOfTagKey(101) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
 	return sz
 }
 
@@ -1747,12 +1796,20 @@ func (m *AllOptionalFields) Unmarshal(p []byte) error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *EmptyExtension) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
 	return sz
 }
 
@@ -1812,9 +1869,15 @@ func (m *EmptyExtension) Unmarshal(p []byte) error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent_NestedMsg) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.XXX_sizecache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -1823,6 +1886,8 @@ func (m *TestEvent_NestedMsg) Size() int {
 		l = len(*m.Details)
 		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.XXX_sizecache, int32(sz))
 	return sz
 }
 

--- a/example/proto2/googlev1/googlev1_proto2_example.pb.fm.go
+++ b/example/proto2/googlev1/googlev1_proto2_example.pb.fm.go
@@ -6,6 +6,7 @@ package googlev1
 import (
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -15,9 +16,15 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *BaseEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -48,6 +55,8 @@ func (m *BaseEvent) Size() int {
 		sz += csproto.SizeOfTagKey(100) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -233,9 +242,15 @@ func (m *BaseEvent) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -283,6 +298,8 @@ func (m *TestEvent) Size() int {
 		}
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -504,9 +521,15 @@ func (m *TestEvent) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *EmbeddedEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -525,10 +548,11 @@ func (m *EmbeddedEvent) Size() int {
 	}
 	// RandomThings (bytes,repeated)
 	for _, bv := range m.RandomThings {
-		if l = len(bv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(bv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -680,9 +704,15 @@ func (m *EmbeddedEvent) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *AllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -759,6 +789,8 @@ func (m *AllTheThings) Size() int {
 		l = csproto.Size(m.TheMessage)
 		sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -1090,9 +1122,15 @@ func (m *AllTheThings) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *RepeatAllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -1163,9 +1201,8 @@ func (m *RepeatAllTheThings) Size() int {
 	}
 	// TheBytes (bytes,repeated)
 	for _, bv := range m.TheBytes {
-		if l = len(bv); l > 0 {
-			sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(bv)
+		sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheMessages (message,repeated)
 	for _, val := range m.TheMessages {
@@ -1173,6 +1210,8 @@ func (m *RepeatAllTheThings) Size() int {
 			sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 		}
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -1601,9 +1640,15 @@ func (m *RepeatAllTheThings) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent_NestedMsg) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -1612,6 +1657,8 @@ func (m *TestEvent_NestedMsg) Size() int {
 		l = len(*m.Details)
 		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 

--- a/example/proto2/googlev2/googlev2_proto2_example.pb.fm.go
+++ b/example/proto2/googlev2/googlev2_proto2_example.pb.fm.go
@@ -6,6 +6,7 @@ package googlev2
 import (
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 )
 
@@ -15,9 +16,15 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *BaseEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -48,6 +55,8 @@ func (m *BaseEvent) Size() int {
 		sz += csproto.SizeOfTagKey(100) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -233,9 +242,15 @@ func (m *BaseEvent) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -283,6 +298,8 @@ func (m *TestEvent) Size() int {
 		}
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -504,9 +521,15 @@ func (m *TestEvent) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *EmbeddedEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -525,10 +548,11 @@ func (m *EmbeddedEvent) Size() int {
 	}
 	// RandomThings (bytes,repeated)
 	for _, bv := range m.RandomThings {
-		if l = len(bv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(bv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -680,9 +704,15 @@ func (m *EmbeddedEvent) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *AllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -759,6 +789,8 @@ func (m *AllTheThings) Size() int {
 		l = csproto.Size(m.TheMessage)
 		sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -1090,9 +1122,15 @@ func (m *AllTheThings) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *RepeatAllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -1163,9 +1201,8 @@ func (m *RepeatAllTheThings) Size() int {
 	}
 	// TheBytes (bytes,repeated)
 	for _, bv := range m.TheBytes {
-		if l = len(bv); l > 0 {
-			sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(bv)
+		sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheMessages (message,repeated)
 	for _, val := range m.TheMessages {
@@ -1173,6 +1210,8 @@ func (m *RepeatAllTheThings) Size() int {
 			sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 		}
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -1601,9 +1640,15 @@ func (m *RepeatAllTheThings) csprotoCheckRequiredFields() error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent_NestedMsg) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
@@ -1612,6 +1657,8 @@ func (m *TestEvent_NestedMsg) Size() int {
 		l = len(*m.Details)
 		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 

--- a/example/proto3/googlev1/googlev1_proto3_example.pb.fm.go
+++ b/example/proto3/googlev1/googlev1_proto3_example.pb.fm.go
@@ -5,6 +5,7 @@ package googlev1
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -16,20 +17,30 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// Name (string,optional)
-	l = len(m.Name)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Name); l > 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// Info (string,optional)
-	l = len(m.Info)
-	sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Info); l > 0 {
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// IsAwesome (bool,optional)
-	sz += csproto.SizeOfTagKey(3) + 1
+	if m.IsAwesome {
+		sz += csproto.SizeOfTagKey(3) + 1
+	}
 	// Labels (string,repeated)
 	for _, sv := range m.Labels {
 		l = len(sv)
@@ -51,7 +62,9 @@ func (m *TestEvent) Size() int {
 		sz += csproto.SizeOfTagKey(10) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// NullVal (enum,optional)
-	sz += csproto.SizeOfTagKey(11) + csproto.SizeOfVarint(uint64(m.NullVal))
+	if m.NullVal != 0 {
+		sz += csproto.SizeOfTagKey(11) + csproto.SizeOfVarint(uint64(m.NullVal))
+	}
 	// Path (oneof)
 	if m.Path != nil {
 		switch typedVal := m.Path.(type) {
@@ -67,6 +80,8 @@ func (m *TestEvent) Size() int {
 		}
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -93,11 +108,17 @@ func (m *TestEvent) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// Name (1,string,optional)
-	enc.EncodeString(1, m.Name)
+	if len(m.Name) > 0 {
+		enc.EncodeString(1, m.Name)
+	}
 	// Info (2,string,optional)
-	enc.EncodeString(2, m.Info)
+	if len(m.Info) > 0 {
+		enc.EncodeString(2, m.Info)
+	}
 	// IsAwesome (3,bool,optional)
-	enc.EncodeBool(3, m.IsAwesome)
+	if m.IsAwesome {
+		enc.EncodeBool(3, m.IsAwesome)
+	}
 	// Labels (4,string,repeated)
 	for _, val := range m.Labels {
 		enc.EncodeString(4, val)
@@ -121,7 +142,9 @@ func (m *TestEvent) MarshalTo(dest []byte) error {
 		}
 	}
 	// NullVal (11,enum,optional)
-	enc.EncodeInt32(11, int32(m.NullVal))
+	if m.NullVal != 0 {
+		enc.EncodeInt32(11, int32(m.NullVal))
+	}
 	// Path (oneof)
 	if m.Path != nil {
 		switch typedVal := m.Path.(type) {
@@ -279,17 +302,26 @@ func (m *TestEvent) Unmarshal(p []byte) error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *EmbeddedEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// ID (int32,optional)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	if m.ID != 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	}
 	// Stuff (string,optional)
-	l = len(m.Stuff)
-	sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Stuff); l > 0 {
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// FavoriteNumbers (int32,repeated,packed)
 	if len(m.FavoriteNumbers) > 0 {
 		sz += csproto.SizeOfTagKey(3)
@@ -301,10 +333,11 @@ func (m *EmbeddedEvent) Size() int {
 	}
 	// RandomThings (bytes,repeated)
 	for _, bv := range m.RandomThings {
-		if l = len(bv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(bv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -331,9 +364,13 @@ func (m *EmbeddedEvent) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// ID (1,int32,optional)
-	enc.EncodeInt32(1, m.ID)
+	if m.ID != 0 {
+		enc.EncodeInt32(1, m.ID)
+	}
 	// Stuff (2,string,optional)
-	enc.EncodeString(2, m.Stuff)
+	if len(m.Stuff) > 0 {
+		enc.EncodeString(2, m.Stuff)
+	}
 	// FavoriteNumbers (3,int32,repeated,packed)
 	if len(m.FavoriteNumbers) > 0 {
 		enc.EncodePackedInt32(3, m.FavoriteNumbers)
@@ -423,53 +460,93 @@ func (m *EmbeddedEvent) Unmarshal(p []byte) error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *AllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// ID (int32,optional)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	if m.ID != 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	}
 	// TheString (string,optional)
-	l = len(m.TheString)
-	sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.TheString); l > 0 {
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// TheBool (bool,optional)
-	sz += csproto.SizeOfTagKey(3) + 1
+	if m.TheBool {
+		sz += csproto.SizeOfTagKey(3) + 1
+	}
 	// TheInt32 (int32,optional)
-	sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(m.TheInt32))
+	if m.TheInt32 != 0 {
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(m.TheInt32))
+	}
 	// TheInt64 (int64,optional)
-	sz += csproto.SizeOfTagKey(5) + csproto.SizeOfVarint(uint64(m.TheInt64))
+	if m.TheInt64 != 0 {
+		sz += csproto.SizeOfTagKey(5) + csproto.SizeOfVarint(uint64(m.TheInt64))
+	}
 	// TheUInt32 (uint32,optional)
-	sz += csproto.SizeOfTagKey(6) + csproto.SizeOfVarint(uint64(m.TheUInt32))
+	if m.TheUInt32 != 0 {
+		sz += csproto.SizeOfTagKey(6) + csproto.SizeOfVarint(uint64(m.TheUInt32))
+	}
 	// TheUInt64 (uint64,optional)
-	sz += csproto.SizeOfTagKey(7) + csproto.SizeOfVarint(uint64(m.TheUInt64))
+	if m.TheUInt64 != 0 {
+		sz += csproto.SizeOfTagKey(7) + csproto.SizeOfVarint(uint64(m.TheUInt64))
+	}
 	// TheSInt32 (sint32,optional)
-	sz += csproto.SizeOfTagKey(8) + csproto.SizeOfZigZag(uint64(m.TheSInt32))
+	if m.TheSInt32 != 0 {
+		sz += csproto.SizeOfTagKey(8) + csproto.SizeOfZigZag(uint64(m.TheSInt32))
+	}
 	// TheSInt64 (sint64,optional)
-	sz += csproto.SizeOfTagKey(9) + csproto.SizeOfZigZag(uint64(m.TheSInt64))
+	if m.TheSInt64 != 0 {
+		sz += csproto.SizeOfTagKey(9) + csproto.SizeOfZigZag(uint64(m.TheSInt64))
+	}
 	// TheFixed32 (fixed32,optional)
-	sz += csproto.SizeOfTagKey(10) + 4
+	if m.TheFixed32 != 0 {
+		sz += csproto.SizeOfTagKey(10) + 4
+	}
 	// TheFixed64 (fixed64,optional)
-	sz += csproto.SizeOfTagKey(11) + 8
+	if m.TheFixed64 != 0 {
+		sz += csproto.SizeOfTagKey(11) + 8
+	}
 	// TheSFixed32 (sfixed32,optional)
-	sz += csproto.SizeOfTagKey(12) + 4
+	if m.TheSFixed32 != 0 {
+		sz += csproto.SizeOfTagKey(12) + 4
+	}
 	// TheSFixed64 (sfixed64,optional)
-	sz += csproto.SizeOfTagKey(13) + 8
+	if m.TheSFixed64 != 0 {
+		sz += csproto.SizeOfTagKey(13) + 8
+	}
 	// TheFloat (float,optional)
-	sz += csproto.SizeOfTagKey(14) + 4
+	if m.TheFloat != 0 {
+		sz += csproto.SizeOfTagKey(14) + 4
+	}
 	// TheDouble (double,optional)
-	sz += csproto.SizeOfTagKey(15) + 8
+	if m.TheDouble != 0 {
+		sz += csproto.SizeOfTagKey(15) + 8
+	}
 	// TheEventType (enum,optional)
-	sz += csproto.SizeOfTagKey(16) + csproto.SizeOfVarint(uint64(m.TheEventType))
+	if m.TheEventType != 0 {
+		sz += csproto.SizeOfTagKey(16) + csproto.SizeOfVarint(uint64(m.TheEventType))
+	}
 	// TheBytes (bytes,optional)
-	l = len(m.TheBytes)
-	sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.TheBytes); l > 0 {
+		sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// TheMessage (message,optional)
 	if m.TheMessage != nil {
 		l = csproto.Size(m.TheMessage)
 		sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -496,39 +573,69 @@ func (m *AllTheThings) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// ID (1,int32,optional)
-	enc.EncodeInt32(1, m.ID)
+	if m.ID != 0 {
+		enc.EncodeInt32(1, m.ID)
+	}
 	// TheString (2,string,optional)
-	enc.EncodeString(2, m.TheString)
+	if len(m.TheString) > 0 {
+		enc.EncodeString(2, m.TheString)
+	}
 	// TheBool (3,bool,optional)
-	enc.EncodeBool(3, m.TheBool)
+	if m.TheBool {
+		enc.EncodeBool(3, m.TheBool)
+	}
 	// TheInt32 (4,int32,optional)
-	enc.EncodeInt32(4, m.TheInt32)
+	if m.TheInt32 != 0 {
+		enc.EncodeInt32(4, m.TheInt32)
+	}
 	// TheInt64 (5,int64,optional)
-	enc.EncodeInt64(5, m.TheInt64)
+	if m.TheInt64 != 0 {
+		enc.EncodeInt64(5, m.TheInt64)
+	}
 	// TheUInt32 (6,uint32,optional)
-	enc.EncodeUInt32(6, m.TheUInt32)
+	if m.TheUInt32 != 0 {
+		enc.EncodeUInt32(6, m.TheUInt32)
+	}
 	// TheUInt64 (7,uint64,optional)
-	enc.EncodeUInt64(7, m.TheUInt64)
+	if m.TheUInt64 != 0 {
+		enc.EncodeUInt64(7, m.TheUInt64)
+	}
 	// TheSInt32 (8,sint32,optional)
-	enc.EncodeSInt32(8, m.TheSInt32)
+	if m.TheSInt32 != 0 {
+		enc.EncodeSInt32(8, m.TheSInt32)
+	}
 	// TheSInt64 (9,sint64,optional)
-	enc.EncodeSInt64(9, m.TheSInt64)
+	if m.TheSInt64 != 0 {
+		enc.EncodeSInt64(9, m.TheSInt64)
+	}
 	// TheFixed32 (10,fixed32,optional)
-	enc.EncodeFixed32(10, m.TheFixed32)
+	if m.TheFixed32 != 0 {
+		enc.EncodeFixed32(10, m.TheFixed32)
+	}
 	// TheFixed64 (11,fixed64,optional)
-	enc.EncodeFixed64(11, m.TheFixed64)
+	if m.TheFixed64 != 0 {
+		enc.EncodeFixed64(11, m.TheFixed64)
+	}
 	// TheSFixed32 (12,sfixed32,optional)
 	enc.EncodeFixed32(12, uint32(m.TheSFixed32))
 	// TheSFixed64 (13,sfixed64,optional)
 	enc.EncodeFixed64(13, uint64(m.TheSFixed64))
 	// TheFloat (14,float,optional)
-	enc.EncodeFloat32(14, m.TheFloat)
+	if m.TheFloat != 0 {
+		enc.EncodeFloat32(14, m.TheFloat)
+	}
 	// TheDouble (15,double,optional)
-	enc.EncodeFloat64(15, m.TheDouble)
+	if m.TheDouble != 0 {
+		enc.EncodeFloat64(15, m.TheDouble)
+	}
 	// TheEventType (16,enum,optional)
-	enc.EncodeInt32(16, int32(m.TheEventType))
+	if m.TheEventType != 0 {
+		enc.EncodeInt32(16, int32(m.TheEventType))
+	}
 	// TheBytes (17,bytes,optional)
-	enc.EncodeBytes(17, m.TheBytes)
+	if len(m.TheBytes) > 0 {
+		enc.EncodeBytes(17, m.TheBytes)
+	}
 	// TheMessage (18,message,optional)
 	if m.TheMessage != nil {
 		if err = enc.EncodeNested(18, m.TheMessage); err != nil {
@@ -737,14 +844,22 @@ func (m *AllTheThings) Unmarshal(p []byte) error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *RepeatAllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// ID (int32,optional)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	if m.ID != 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	}
 	// TheStrings (string,repeated)
 	for _, sv := range m.TheStrings {
 		l = len(sv)
@@ -843,9 +958,8 @@ func (m *RepeatAllTheThings) Size() int {
 	}
 	// TheBytes (bytes,repeated)
 	for _, bv := range m.TheBytes {
-		if l = len(bv); l > 0 {
-			sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(bv)
+		sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheMessages (message,repeated)
 	for _, val := range m.TheMessages {
@@ -853,6 +967,8 @@ func (m *RepeatAllTheThings) Size() int {
 			sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 		}
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -879,7 +995,9 @@ func (m *RepeatAllTheThings) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// ID (1,int32,optional)
-	enc.EncodeInt32(1, m.ID)
+	if m.ID != 0 {
+		enc.EncodeInt32(1, m.ID)
+	}
 	// TheStrings (2,string,repeated)
 	for _, val := range m.TheStrings {
 		enc.EncodeString(2, val)
@@ -1254,15 +1372,24 @@ func (m *RepeatAllTheThings) Unmarshal(p []byte) error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent_NestedMsg) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// Details (string,optional)
-	l = len(m.Details)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Details); l > 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -1289,7 +1416,9 @@ func (m *TestEvent_NestedMsg) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// Details (1,string,optional)
-	enc.EncodeString(1, m.Details)
+	if len(m.Details) > 0 {
+		enc.EncodeString(1, m.Details)
+	}
 	return nil
 }
 

--- a/example/proto3/googlev2/googlev2_proto3_example.pb.fm.go
+++ b/example/proto3/googlev2/googlev2_proto3_example.pb.fm.go
@@ -5,6 +5,7 @@ package googlev2
 
 import (
 	"fmt"
+	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -16,20 +17,30 @@ import (
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// Name (string,optional)
-	l = len(m.Name)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Name); l > 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// Info (string,optional)
-	l = len(m.Info)
-	sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Info); l > 0 {
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// IsAwesome (bool,optional)
-	sz += csproto.SizeOfTagKey(3) + 1
+	if m.IsAwesome {
+		sz += csproto.SizeOfTagKey(3) + 1
+	}
 	// Labels (string,repeated)
 	for _, sv := range m.Labels {
 		l = len(sv)
@@ -51,7 +62,9 @@ func (m *TestEvent) Size() int {
 		sz += csproto.SizeOfTagKey(10) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// NullVal (enum,optional)
-	sz += csproto.SizeOfTagKey(11) + csproto.SizeOfVarint(uint64(m.NullVal))
+	if m.NullVal != 0 {
+		sz += csproto.SizeOfTagKey(11) + csproto.SizeOfVarint(uint64(m.NullVal))
+	}
 	// Path (oneof)
 	if m.Path != nil {
 		switch typedVal := m.Path.(type) {
@@ -67,6 +80,8 @@ func (m *TestEvent) Size() int {
 		}
 	}
 
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -93,11 +108,17 @@ func (m *TestEvent) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// Name (1,string,optional)
-	enc.EncodeString(1, m.Name)
+	if len(m.Name) > 0 {
+		enc.EncodeString(1, m.Name)
+	}
 	// Info (2,string,optional)
-	enc.EncodeString(2, m.Info)
+	if len(m.Info) > 0 {
+		enc.EncodeString(2, m.Info)
+	}
 	// IsAwesome (3,bool,optional)
-	enc.EncodeBool(3, m.IsAwesome)
+	if m.IsAwesome {
+		enc.EncodeBool(3, m.IsAwesome)
+	}
 	// Labels (4,string,repeated)
 	for _, val := range m.Labels {
 		enc.EncodeString(4, val)
@@ -121,7 +142,9 @@ func (m *TestEvent) MarshalTo(dest []byte) error {
 		}
 	}
 	// NullVal (11,enum,optional)
-	enc.EncodeInt32(11, int32(m.NullVal))
+	if m.NullVal != 0 {
+		enc.EncodeInt32(11, int32(m.NullVal))
+	}
 	// Path (oneof)
 	if m.Path != nil {
 		switch typedVal := m.Path.(type) {
@@ -279,17 +302,26 @@ func (m *TestEvent) Unmarshal(p []byte) error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *EmbeddedEvent) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// ID (int32,optional)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	if m.ID != 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	}
 	// Stuff (string,optional)
-	l = len(m.Stuff)
-	sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Stuff); l > 0 {
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// FavoriteNumbers (int32,repeated,packed)
 	if len(m.FavoriteNumbers) > 0 {
 		sz += csproto.SizeOfTagKey(3)
@@ -301,10 +333,11 @@ func (m *EmbeddedEvent) Size() int {
 	}
 	// RandomThings (bytes,repeated)
 	for _, bv := range m.RandomThings {
-		if l = len(bv); l > 0 {
-			sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(bv)
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -331,9 +364,13 @@ func (m *EmbeddedEvent) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// ID (1,int32,optional)
-	enc.EncodeInt32(1, m.ID)
+	if m.ID != 0 {
+		enc.EncodeInt32(1, m.ID)
+	}
 	// Stuff (2,string,optional)
-	enc.EncodeString(2, m.Stuff)
+	if len(m.Stuff) > 0 {
+		enc.EncodeString(2, m.Stuff)
+	}
 	// FavoriteNumbers (3,int32,repeated,packed)
 	if len(m.FavoriteNumbers) > 0 {
 		enc.EncodePackedInt32(3, m.FavoriteNumbers)
@@ -423,53 +460,93 @@ func (m *EmbeddedEvent) Unmarshal(p []byte) error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *AllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// ID (int32,optional)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	if m.ID != 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	}
 	// TheString (string,optional)
-	l = len(m.TheString)
-	sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.TheString); l > 0 {
+		sz += csproto.SizeOfTagKey(2) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// TheBool (bool,optional)
-	sz += csproto.SizeOfTagKey(3) + 1
+	if m.TheBool {
+		sz += csproto.SizeOfTagKey(3) + 1
+	}
 	// TheInt32 (int32,optional)
-	sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(m.TheInt32))
+	if m.TheInt32 != 0 {
+		sz += csproto.SizeOfTagKey(4) + csproto.SizeOfVarint(uint64(m.TheInt32))
+	}
 	// TheInt64 (int64,optional)
-	sz += csproto.SizeOfTagKey(5) + csproto.SizeOfVarint(uint64(m.TheInt64))
+	if m.TheInt64 != 0 {
+		sz += csproto.SizeOfTagKey(5) + csproto.SizeOfVarint(uint64(m.TheInt64))
+	}
 	// TheUInt32 (uint32,optional)
-	sz += csproto.SizeOfTagKey(6) + csproto.SizeOfVarint(uint64(m.TheUInt32))
+	if m.TheUInt32 != 0 {
+		sz += csproto.SizeOfTagKey(6) + csproto.SizeOfVarint(uint64(m.TheUInt32))
+	}
 	// TheUInt64 (uint64,optional)
-	sz += csproto.SizeOfTagKey(7) + csproto.SizeOfVarint(uint64(m.TheUInt64))
+	if m.TheUInt64 != 0 {
+		sz += csproto.SizeOfTagKey(7) + csproto.SizeOfVarint(uint64(m.TheUInt64))
+	}
 	// TheSInt32 (sint32,optional)
-	sz += csproto.SizeOfTagKey(8) + csproto.SizeOfZigZag(uint64(m.TheSInt32))
+	if m.TheSInt32 != 0 {
+		sz += csproto.SizeOfTagKey(8) + csproto.SizeOfZigZag(uint64(m.TheSInt32))
+	}
 	// TheSInt64 (sint64,optional)
-	sz += csproto.SizeOfTagKey(9) + csproto.SizeOfZigZag(uint64(m.TheSInt64))
+	if m.TheSInt64 != 0 {
+		sz += csproto.SizeOfTagKey(9) + csproto.SizeOfZigZag(uint64(m.TheSInt64))
+	}
 	// TheFixed32 (fixed32,optional)
-	sz += csproto.SizeOfTagKey(10) + 4
+	if m.TheFixed32 != 0 {
+		sz += csproto.SizeOfTagKey(10) + 4
+	}
 	// TheFixed64 (fixed64,optional)
-	sz += csproto.SizeOfTagKey(11) + 8
+	if m.TheFixed64 != 0 {
+		sz += csproto.SizeOfTagKey(11) + 8
+	}
 	// TheSFixed32 (sfixed32,optional)
-	sz += csproto.SizeOfTagKey(12) + 4
+	if m.TheSFixed32 != 0 {
+		sz += csproto.SizeOfTagKey(12) + 4
+	}
 	// TheSFixed64 (sfixed64,optional)
-	sz += csproto.SizeOfTagKey(13) + 8
+	if m.TheSFixed64 != 0 {
+		sz += csproto.SizeOfTagKey(13) + 8
+	}
 	// TheFloat (float,optional)
-	sz += csproto.SizeOfTagKey(14) + 4
+	if m.TheFloat != 0 {
+		sz += csproto.SizeOfTagKey(14) + 4
+	}
 	// TheDouble (double,optional)
-	sz += csproto.SizeOfTagKey(15) + 8
+	if m.TheDouble != 0 {
+		sz += csproto.SizeOfTagKey(15) + 8
+	}
 	// TheEventType (enum,optional)
-	sz += csproto.SizeOfTagKey(16) + csproto.SizeOfVarint(uint64(m.TheEventType))
+	if m.TheEventType != 0 {
+		sz += csproto.SizeOfTagKey(16) + csproto.SizeOfVarint(uint64(m.TheEventType))
+	}
 	// TheBytes (bytes,optional)
-	l = len(m.TheBytes)
-	sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.TheBytes); l > 0 {
+		sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
+	}
 	// TheMessage (message,optional)
 	if m.TheMessage != nil {
 		l = csproto.Size(m.TheMessage)
 		sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -496,39 +573,69 @@ func (m *AllTheThings) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// ID (1,int32,optional)
-	enc.EncodeInt32(1, m.ID)
+	if m.ID != 0 {
+		enc.EncodeInt32(1, m.ID)
+	}
 	// TheString (2,string,optional)
-	enc.EncodeString(2, m.TheString)
+	if len(m.TheString) > 0 {
+		enc.EncodeString(2, m.TheString)
+	}
 	// TheBool (3,bool,optional)
-	enc.EncodeBool(3, m.TheBool)
+	if m.TheBool {
+		enc.EncodeBool(3, m.TheBool)
+	}
 	// TheInt32 (4,int32,optional)
-	enc.EncodeInt32(4, m.TheInt32)
+	if m.TheInt32 != 0 {
+		enc.EncodeInt32(4, m.TheInt32)
+	}
 	// TheInt64 (5,int64,optional)
-	enc.EncodeInt64(5, m.TheInt64)
+	if m.TheInt64 != 0 {
+		enc.EncodeInt64(5, m.TheInt64)
+	}
 	// TheUInt32 (6,uint32,optional)
-	enc.EncodeUInt32(6, m.TheUInt32)
+	if m.TheUInt32 != 0 {
+		enc.EncodeUInt32(6, m.TheUInt32)
+	}
 	// TheUInt64 (7,uint64,optional)
-	enc.EncodeUInt64(7, m.TheUInt64)
+	if m.TheUInt64 != 0 {
+		enc.EncodeUInt64(7, m.TheUInt64)
+	}
 	// TheSInt32 (8,sint32,optional)
-	enc.EncodeSInt32(8, m.TheSInt32)
+	if m.TheSInt32 != 0 {
+		enc.EncodeSInt32(8, m.TheSInt32)
+	}
 	// TheSInt64 (9,sint64,optional)
-	enc.EncodeSInt64(9, m.TheSInt64)
+	if m.TheSInt64 != 0 {
+		enc.EncodeSInt64(9, m.TheSInt64)
+	}
 	// TheFixed32 (10,fixed32,optional)
-	enc.EncodeFixed32(10, m.TheFixed32)
+	if m.TheFixed32 != 0 {
+		enc.EncodeFixed32(10, m.TheFixed32)
+	}
 	// TheFixed64 (11,fixed64,optional)
-	enc.EncodeFixed64(11, m.TheFixed64)
+	if m.TheFixed64 != 0 {
+		enc.EncodeFixed64(11, m.TheFixed64)
+	}
 	// TheSFixed32 (12,sfixed32,optional)
 	enc.EncodeFixed32(12, uint32(m.TheSFixed32))
 	// TheSFixed64 (13,sfixed64,optional)
 	enc.EncodeFixed64(13, uint64(m.TheSFixed64))
 	// TheFloat (14,float,optional)
-	enc.EncodeFloat32(14, m.TheFloat)
+	if m.TheFloat != 0 {
+		enc.EncodeFloat32(14, m.TheFloat)
+	}
 	// TheDouble (15,double,optional)
-	enc.EncodeFloat64(15, m.TheDouble)
+	if m.TheDouble != 0 {
+		enc.EncodeFloat64(15, m.TheDouble)
+	}
 	// TheEventType (16,enum,optional)
-	enc.EncodeInt32(16, int32(m.TheEventType))
+	if m.TheEventType != 0 {
+		enc.EncodeInt32(16, int32(m.TheEventType))
+	}
 	// TheBytes (17,bytes,optional)
-	enc.EncodeBytes(17, m.TheBytes)
+	if len(m.TheBytes) > 0 {
+		enc.EncodeBytes(17, m.TheBytes)
+	}
 	// TheMessage (18,message,optional)
 	if m.TheMessage != nil {
 		if err = enc.EncodeNested(18, m.TheMessage); err != nil {
@@ -737,14 +844,22 @@ func (m *AllTheThings) Unmarshal(p []byte) error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *RepeatAllTheThings) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// ID (int32,optional)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	if m.ID != 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(m.ID))
+	}
 	// TheStrings (string,repeated)
 	for _, sv := range m.TheStrings {
 		l = len(sv)
@@ -843,9 +958,8 @@ func (m *RepeatAllTheThings) Size() int {
 	}
 	// TheBytes (bytes,repeated)
 	for _, bv := range m.TheBytes {
-		if l = len(bv); l > 0 {
-			sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
-		}
+		l = len(bv)
+		sz += csproto.SizeOfTagKey(17) + csproto.SizeOfVarint(uint64(l)) + l
 	}
 	// TheMessages (message,repeated)
 	for _, val := range m.TheMessages {
@@ -853,6 +967,8 @@ func (m *RepeatAllTheThings) Size() int {
 			sz += csproto.SizeOfTagKey(18) + csproto.SizeOfVarint(uint64(l)) + l
 		}
 	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -879,7 +995,9 @@ func (m *RepeatAllTheThings) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// ID (1,int32,optional)
-	enc.EncodeInt32(1, m.ID)
+	if m.ID != 0 {
+		enc.EncodeInt32(1, m.ID)
+	}
 	// TheStrings (2,string,repeated)
 	for _, val := range m.TheStrings {
 		enc.EncodeString(2, val)
@@ -1254,15 +1372,24 @@ func (m *RepeatAllTheThings) Unmarshal(p []byte) error {
 // Size calculates and returns the size, in bytes, required to hold the contents of m using the Protobuf
 // binary encoding.
 func (m *TestEvent_NestedMsg) Size() int {
+	// nil message is always 0 bytes
 	if m == nil {
 		return 0
 	}
+	// return cached size, if present
+	if csz := int(atomic.LoadInt32(&m.sizeCache)); csz > 0 {
+		return csz
+	}
+	// calculate and cache
 	var sz, l int
 	_ = l // avoid unused variable
 
 	// Details (string,optional)
-	l = len(m.Details)
-	sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	if l = len(m.Details); l > 0 {
+		sz += csproto.SizeOfTagKey(1) + csproto.SizeOfVarint(uint64(l)) + l
+	}
+	// cache the size so it can be re-used in Marshal()/MarshalTo()
+	atomic.StoreInt32(&m.sizeCache, int32(sz))
 	return sz
 }
 
@@ -1289,7 +1416,9 @@ func (m *TestEvent_NestedMsg) MarshalTo(dest []byte) error {
 	_ = extVal
 
 	// Details (1,string,optional)
-	enc.EncodeString(1, m.Details)
+	if len(m.Details) > 0 {
+		enc.EncodeString(1, m.Details)
+	}
 	return nil
 }
 


### PR DESCRIPTION
add logic in generated code to cache calculated size to avoid double work across `Size()` and `MarshalTo()`
modify codegen templates to skip zero-valued fields when sizing and marshaling proto3 messages