### PR TITLE
fix(codegen): correct invalid generated code for float or double oneof fields

### DIFF
--- a/cmd/protoc-gen-fastmarshal/templates/fieldsnippets.tmpl
+++ b/cmd/protoc-gen-fastmarshal/templates/fieldsnippets.tmpl
@@ -1280,7 +1280,7 @@
             if wt != csproto.WireTypeFixed{{$bitSize}} {
                 return fmt.Errorf("incorrect wire type %v for tag field '{{.Desc.Name}}' (tag={{.Desc.Number}}), expected {{if eq $bitSize "32"}}5 (32-bit){{else}}1 (64-bit){{end}}", wt)
             }
-            if v, err := dec.DecodeFixed{{$bitSize}}(); err != nil {
+            if v, err := dec.DecodeFloat{{$bitSize}}(); err != nil {
                 return fmt.Errorf("unable to decode {{$kind}} value for field '{{.Desc.Name}}' (tag={{.Desc.Number}}): %w", err)
             } else {
                 ov.{{.GoName | getSafeFieldName}}= v


### PR DESCRIPTION
fixed copy/paste bug in the codegen template
float/double fields should use `DecodeFloat*` instead of `DecodeFixed*`

fixes #54