### PR TITLE
fix(protoc-gen-fastmarshal): incorrect size calculation for message oneof fields

### DIFF
--- a/cmd/protoc-gen-fastmarshal/templates/fieldsnippets.tmpl
+++ b/cmd/protoc-gen-fastmarshal/templates/fieldsnippets.tmpl
@@ -242,7 +242,9 @@
             {{- else if eq $kind "sint32" "sint64" -}}
             sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfZigZag(uint64(typedVal.{{.GoName | getSafeFieldName}}))
             {{- else if eq $kind "message" -}}
-            sz += csproto.Size(typedVal.{{.GoName | getSafeFieldName}})
+            if l = csproto.Size(typedVal.{{.GoName | getSafeFieldName }}); l > 0 {
+                sz += csproto.SizeOfTagKey({{.Desc.Number}}) + csproto.SizeOfVarint(uint64(l)) + l
+            }
             {{- end }}
         {{ end -}}
         default:


### PR DESCRIPTION
Message fields are length-delimited binary but the size calculation was not including the field tag and length, resulting in panics when writing past the end of the allocated buffer inside of `csproto.Marshal()`.

This PR updates the code generation templates for `protoc-gen-fastmarshal` to correct the calculation.