### PR TITLE
feat: add csproto.Equal

### DIFF
--- a/equal.go
+++ b/equal.go
@@ -1,0 +1,29 @@
+package csproto
+
+import (
+	gogo "github.com/gogo/protobuf/proto"
+	google "github.com/golang/protobuf/proto" //nolint: staticcheck // we're using this deprecated package intentionally
+	googlev2 "google.golang.org/protobuf/proto"
+)
+
+// Equal returns true iff m1 and m2 are equal.
+//
+// If m1 and m2 are not the same "type" (generated for the same runtime) then they are not equal.  Otherwise,
+// we delegate comparison to the appropriate underlying Protobuf API based on the concrete type of the
+// messages
+func Equal(m1, m2 interface{}) bool {
+	t1, t2 := MsgType(m1), MsgType(m2)
+	if t1 != t2 {
+		return false
+	}
+	switch t1 {
+	case MessageTypeGoogleV1:
+		return google.Equal(m1.(google.Message), m2.(google.Message))
+	case MessageTypeGoogle:
+		return googlev2.Equal(m1.(googlev2.Message), m2.(googlev2.Message))
+	case MessageTypeGogo:
+		return gogo.Equal(m1.(gogo.Message), m2.(gogo.Message))
+	default:
+		return false
+	}
+}

--- a/example/proto2_gogo_test.go
+++ b/example/proto2_gogo_test.go
@@ -165,6 +165,17 @@ func TestProto2GogoMarshalText(t *testing.T) {
 	assert.Equal(t, expected, s)
 }
 
+func TestProto2GogoEqual(t *testing.T) {
+	m1 := createTestProto2GogoMessage()
+	m2 := createTestProto2GogoMessage()
+	*m2.Timestamp = *m1.Timestamp + 1
+	// m1 and m2 will have different timestamps so should not be equal
+	assert.False(t, csproto.Equal(m1, m2), "messages should not be equal\nm1=%s\nm2=%s", m1.String(), m2.String())
+	// make them equal
+	*m2.Timestamp = *m1.Timestamp
+	assert.True(t, csproto.Equal(m1, m2), "messages should be equal\nm1=%s\nm2=%s", m1.String(), m2.String())
+}
+
 func createTestProto2GogoMessage() *gogo.BaseEvent {
 	now := uint64(time.Now().UTC().Unix())
 	et := gogo.EventType_EVENT_TYPE_ONE

--- a/example/proto2_googlev1_test.go
+++ b/example/proto2_googlev1_test.go
@@ -178,6 +178,17 @@ func TestProto2GoogleV1MarshalText(t *testing.T) {
 	assert.Equal(t, expected, s)
 }
 
+func TestProto2GoogleV1Equal(t *testing.T) {
+	m1 := createTestProto2GoogleV1Message()
+	m2 := createTestProto2GoogleV1Message()
+	*m2.Timestamp = *m1.Timestamp + 1
+	// m1 and m2 will have different timestamps so should not be equal
+	assert.False(t, csproto.Equal(m1, m2), "messages should not be equal\nm1=%s\nm2=%s", m1.String(), m2.String())
+	// make them equal
+	*m2.Timestamp = *m1.Timestamp
+	assert.True(t, csproto.Equal(m1, m2), "messages should be equal\nm1=%s\nm2=%s", m1.String(), m2.String())
+}
+
 func createTestProto2GoogleV1Message() *googlev1.BaseEvent {
 	now := uint64(time.Now().UTC().Unix())
 	et := googlev1.EventType_EVENT_TYPE_ONE

--- a/example/proto2_googlev2_test.go
+++ b/example/proto2_googlev2_test.go
@@ -178,6 +178,17 @@ func TestProto2GoogleV2MarshalText(t *testing.T) {
 	assert.Equal(t, expected, s)
 }
 
+func TestProto2GoogleV2Equal(t *testing.T) {
+	m1 := createTestProto2GoogleV2Message()
+	m2 := createTestProto2GoogleV2Message()
+	*m2.Timestamp = *m1.Timestamp + 1
+	// m1 and m2 will have different timestamps so should not be equal
+	assert.False(t, csproto.Equal(m1, m2), "messages should not be equal\nm1=%s\nm2=%s", m1.String(), m2.String())
+	// make them equal
+	*m2.Timestamp = *m1.Timestamp
+	assert.True(t, csproto.Equal(m1, m2), "messages should be equal\nm1=%s\nm2=%s", m1.String(), m2.String())
+}
+
 func createTestProto2GoogleV2Message() *googlev2.BaseEvent {
 	now := uint64(time.Now().UTC().Unix())
 	et := googlev2.EventType_EVENT_TYPE_ONE

--- a/example/proto3_gogo_test.go
+++ b/example/proto3_gogo_test.go
@@ -147,6 +147,16 @@ func TestProto3GogoMarshalText(t *testing.T) {
 	assert.Equal(t, expected, s)
 }
 
+func TestProto3GogoEqual(t *testing.T) {
+	m1 := createTestProto3GogoMessage()
+	m2 := createTestProto3GogoMessage()
+	// m1 and m2 will have different timestamps so should not be equal
+	assert.False(t, csproto.Equal(m1, m2), "messages should not be equal\nm1=%s\nm2=%s", m1.String(), m2.String())
+	// make them equal
+	*m2.Ts = *m1.Ts
+	assert.True(t, csproto.Equal(m1, m2), "messages should be equal\nm1=%s\nm2=%s", m1.String(), m2.String())
+}
+
 func createTestProto3GogoMessage() *gogo.TestEvent {
 	event := gogo.TestEvent{
 		Name:   "test",

--- a/example/proto3_googlev1_test.go
+++ b/example/proto3_googlev1_test.go
@@ -155,6 +155,16 @@ func TestProto3GoogleV1MarshalText(t *testing.T) {
 	assert.Equal(t, expected, s)
 }
 
+func TestProto3GoogleV1Equal(t *testing.T) {
+	m1 := createTestProto3GoogleV1Message()
+	m2 := createTestProto3GoogleV1Message()
+	// m1 and m2 will have different timestamps so should not be equal
+	assert.False(t, csproto.Equal(m1, m2), "messages should not be equal\nm1=%s\nm2=%s", m1.String(), m2.String())
+	// make them equal
+	*m2.Ts = *m1.Ts
+	assert.True(t, csproto.Equal(m1, m2), "messages should be equal\nm1=%s\nm2=%s", m1.String(), m2.String())
+}
+
 func createTestProto3GoogleV1Message() *googlev1.TestEvent {
 	event := googlev1.TestEvent{
 		Name:   "test",

--- a/example/proto3_googlev2_test.go
+++ b/example/proto3_googlev2_test.go
@@ -155,6 +155,16 @@ func TestProto3GoogleV2MarshalText(t *testing.T) {
 	assert.Equal(t, expected, s)
 }
 
+func TestProto3GoogleV2Equal(t *testing.T) {
+	m1 := createTestProto3GoogleV2Message()
+	m2 := createTestProto3GoogleV2Message()
+	// m1 and m2 will have different timestamps so should not be equal
+	assert.False(t, csproto.Equal(m1, m2), "messages should not be equal\nm1=%s\nm2=%s", m1.String(), m2.String())
+	// make them equal
+	*m2.Ts = *m1.Ts
+	assert.True(t, csproto.Equal(m1, m2), "messages should be equal\nm1=%s\nm2=%s", m1.String(), m2.String())
+}
+
 func createTestProto3GoogleV2Message() *googlev2.TestEvent {
 	event := googlev2.TestEvent{
 		Name:   "test",


### PR DESCRIPTION
add new Equal function for runtime-agnostic comparisons of proto messages

fixes #74