### PR TITLE
feat: add missing proto APIs

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -86,16 +86,14 @@ func (e *Encoder) EncodeSInt64(tag int, v int64) {
 // preceded by the varint-encoded tag key.
 func (e *Encoder) EncodeFixed32(tag int, v uint32) {
 	e.offset += EncodeTag(e.p[e.offset:], tag, WireTypeFixed32)
-	binary.LittleEndian.PutUint32(e.p[e.offset:], v)
-	e.offset += 4
+	e.offset += EncodeFixed32(e.p[e.offset:], v)
 }
 
 // EncodeFixed64 writes a 64-bit unsigned integer value to the buffer using 8 bytes in little endian format,
 // preceded by the varint-encoded tag key.
 func (e *Encoder) EncodeFixed64(tag int, v uint64) {
 	e.offset += EncodeTag(e.p[e.offset:], tag, WireTypeFixed64)
-	binary.LittleEndian.PutUint64(e.p[e.offset:], v)
-	e.offset += 8
+	e.offset += EncodeFixed64(e.p[e.offset:], v)
 }
 
 // EncodeFloat32 writes a 32-bit IEEE 754 floating point value to the buffer using 4 bytes in little endian format,
@@ -414,6 +412,20 @@ func EncodeVarint(dest []byte, v uint64) int {
 	}
 	dest[n] = uint8(v)
 	return n + 1
+}
+
+// EncodeFixed32 encodes v into dest using the Protobuf fixed 32-bit encoding, which is just the 4 bytes
+// of the value in little-endian format, and returns the number of bytes written
+func EncodeFixed32(dest []byte, v uint32) int {
+	binary.LittleEndian.PutUint32(dest, v)
+	return 4
+}
+
+// EncodeFixed64 encodes v into dest using the Protobuf fixed 64-bit encoding, which is just the 8 bytes
+// of the value in little-endian format, and returns the number of bytes written
+func EncodeFixed64(dest []byte, v uint64) int {
+	binary.LittleEndian.PutUint64(dest, v)
+	return 8
 }
 
 // EncodeZigZag32 encodes v into dest using the Protobuf zig/zag encoding for more efficient encoding

--- a/example/proto2_googlev2_test.go
+++ b/example/proto2_googlev2_test.go
@@ -157,6 +157,95 @@ func TestProto2GoogleV2MarshalJSON(t *testing.T) {
 	})
 }
 
+func TestProto2GoogleV2UnmarshalJSON(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		ts := timestamppb.Now()
+		data := []byte(fmt.Sprintf(`{"eventType":"EVENT_TYPE_UNDEFINED","name":"default","ts":"%s"}`, genGoogleTimestampString(ts)))
+		var msg googlev2.EventUsingWKTs
+
+		err := csproto.JSONUnmarshaler(&msg).UnmarshalJSON(data)
+		assert.NoError(t, err)
+		etype := googlev2.EventType_EVENT_TYPE_UNDEFINED
+		expected := googlev2.EventUsingWKTs{
+			Name:      csproto.String("default"),
+			Ts:        ts,
+			EventType: &etype,
+		}
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+	t.Run("with-unknown-fields", func(t *testing.T) {
+		ts := timestamppb.Now()
+		data := []byte(fmt.Sprintf(`{"eventType":"EVENT_TYPE_UNDEFINED","name":"default","ts":"%s","fdsajkld":"dfjakldfa"}`, genGoogleTimestampString(ts)))
+		var msg googlev2.EventUsingWKTs
+
+		err := csproto.JSONUnmarshaler(&msg).UnmarshalJSON(data)
+		assert.Error(t, err, "JSON unmarshaling should fail if there are unknown fields")
+	})
+	t.Run("allow-unknown-fields", func(t *testing.T) {
+		ts := timestamppb.Now()
+		data := []byte(fmt.Sprintf(`{"eventType":"EVENT_TYPE_UNDEFINED","name":"default","ts":"%s","fdsajkld":"dfjakldfa"}`, genGoogleTimestampString(ts)))
+		var msg googlev2.EventUsingWKTs
+
+		opts := []csproto.JSONOption{
+			csproto.JSONAllowUnknownFields(true),
+		}
+		err := csproto.JSONUnmarshaler(&msg, opts...).UnmarshalJSON(data)
+		assert.NoError(t, err)
+		etype := googlev2.EventType_EVENT_TYPE_UNDEFINED
+		expected := googlev2.EventUsingWKTs{
+			Name:      csproto.String("default"),
+			Ts:        ts,
+			EventType: &etype,
+		}
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+	t.Run("with-missing-required-field", func(t *testing.T) {
+		ts := timestamppb.Now()
+		data := []byte(fmt.Sprintf(`{"eventType":"EVENT_TYPE_UNDEFINED","ts":"%s"}`, genGoogleTimestampString(ts)))
+		var msg googlev2.EventUsingWKTs
+
+		err := csproto.JSONUnmarshaler(&msg).UnmarshalJSON(data)
+		assert.Error(t, err, "JSON unmarshaling should fail if required fields are missing")
+	})
+	t.Run("allow-partial", func(t *testing.T) {
+		ts := timestamppb.Now()
+		data := []byte(fmt.Sprintf(`{"eventType":"EVENT_TYPE_UNDEFINED","ts":"%s"}`, genGoogleTimestampString(ts)))
+		var msg googlev2.EventUsingWKTs
+
+		opts := []csproto.JSONOption{
+			csproto.JSONAllowPartialMessages(true),
+		}
+		err := csproto.JSONUnmarshaler(&msg, opts...).UnmarshalJSON(data)
+		assert.NoError(t, err)
+		etype := googlev2.EventType_EVENT_TYPE_UNDEFINED
+		expected := googlev2.EventUsingWKTs{
+			Name:      nil, // name should not be set
+			Ts:        ts,
+			EventType: &etype,
+		}
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+	t.Run("enable-all", func(t *testing.T) {
+		ts := timestamppb.Now()
+		data := []byte(fmt.Sprintf(`{"eventType":"EVENT_TYPE_UNDEFINED","ts":"%s","fdsajkld":"dfjakldfa"}`, genGoogleTimestampString(ts)))
+		var msg googlev2.EventUsingWKTs
+
+		opts := []csproto.JSONOption{
+			csproto.JSONAllowUnknownFields(true),
+			csproto.JSONAllowPartialMessages(true),
+		}
+		err := csproto.JSONUnmarshaler(&msg, opts...).UnmarshalJSON(data)
+		assert.NoError(t, err)
+		etype := googlev2.EventType_EVENT_TYPE_UNDEFINED
+		expected := googlev2.EventUsingWKTs{
+			Name:      nil, // name should not be set
+			Ts:        ts,
+			EventType: &etype,
+		}
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+}
+
 func TestProto2GoogleV2MarshalText(t *testing.T) {
 	msg := createTestProto2GoogleV2Message()
 	// replace the current date/time with a known value for reproducible output

--- a/example/proto3_gogo_test.go
+++ b/example/proto3_gogo_test.go
@@ -130,6 +130,97 @@ func TestProto3GogoMarshalJSON(t *testing.T) {
 	})
 }
 
+func TestProto3GogoUnmarshalJSON(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		ts := types.TimestampNow()
+		data := []byte(fmt.Sprintf(`{"name":"default","ts":"%s","eventType":"EVENT_TYPE_ONE"}`, genGogoTimestampString(ts)))
+		var msg gogo.EventUsingWKTs
+		expected := gogo.EventUsingWKTs{
+			Name:      "default",
+			Ts:        ts,
+			EventType: gogo.EventType_EVENT_TYPE_ONE,
+		}
+
+		err := csproto.JSONUnmarshaler(&msg).UnmarshalJSON(data)
+		assert.NoError(t, err)
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+	t.Run("with-unknown-fields", func(t *testing.T) {
+		ts := types.TimestampNow()
+		data := []byte(fmt.Sprintf(`{"name":"default","ts":"%s","eventType":"EVENT_TYPE_ONE","dfjaklds":"dfjklad"}`, genGogoTimestampString(ts)))
+		var msg gogo.EventUsingWKTs
+
+		err := csproto.JSONUnmarshaler(&msg).UnmarshalJSON(data)
+		assert.Error(t, err, "JSON unmarshaling should fail if there are unknown fields")
+	})
+	t.Run("allow-unknown-fields", func(t *testing.T) {
+		ts := types.TimestampNow()
+		data := []byte(fmt.Sprintf(`{"name":"default","ts":"%s","eventType":"EVENT_TYPE_ONE","dfjaklds":"dfjklad"}`, genGogoTimestampString(ts)))
+		var msg gogo.EventUsingWKTs
+		expected := gogo.EventUsingWKTs{
+			Name:      "default",
+			Ts:        ts,
+			EventType: gogo.EventType_EVENT_TYPE_ONE,
+		}
+
+		opts := []csproto.JSONOption{
+			csproto.JSONAllowUnknownFields(true),
+		}
+		err := csproto.JSONUnmarshaler(&msg, opts...).UnmarshalJSON(data)
+		assert.NoError(t, err)
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+	t.Run("with-missing-required-fields", func(t *testing.T) {
+		ts := types.TimestampNow()
+		data := []byte(fmt.Sprintf(`{"ts":"%s","eventType":"EVENT_TYPE_ONE"}`, genGogoTimestampString(ts)))
+		var msg gogo.EventUsingWKTs
+		expected := gogo.EventUsingWKTs{
+			Name:      "", // name should not be set
+			Ts:        ts,
+			EventType: gogo.EventType_EVENT_TYPE_ONE,
+		}
+
+		err := csproto.JSONUnmarshaler(&msg).UnmarshalJSON(data)
+		assert.NoError(t, err, "JSON unmarshaling should not fail since proto3 does not have required fields")
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+	t.Run("allow-partial", func(t *testing.T) {
+		ts := types.TimestampNow()
+		data := []byte(fmt.Sprintf(`{"ts":"%s","eventType":"EVENT_TYPE_ONE"}`, genGogoTimestampString(ts)))
+		var msg gogo.EventUsingWKTs
+		expected := gogo.EventUsingWKTs{
+			Name:      "", // name should not be set
+			Ts:        ts,
+			EventType: gogo.EventType_EVENT_TYPE_ONE,
+		}
+
+		opts := []csproto.JSONOption{
+			csproto.JSONAllowPartialMessages(true),
+		}
+		err := csproto.JSONUnmarshaler(&msg, opts...).UnmarshalJSON(data)
+		assert.NoError(t, err, "JSON unmarshaling should not fail since proto3 does not have required fields")
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+	t.Run("enable-all", func(t *testing.T) {
+		ts := types.TimestampNow()
+		data := []byte(fmt.Sprintf(`{"ts":"%s","eventType":"EVENT_TYPE_ONE","dfjaklds":"dfjklad"}`, genGogoTimestampString(ts)))
+		var msg gogo.EventUsingWKTs
+		expected := gogo.EventUsingWKTs{
+			Name:      "", // name should not be set
+			Ts:        ts,
+			EventType: gogo.EventType_EVENT_TYPE_ONE,
+		}
+
+		opts := []csproto.JSONOption{
+			csproto.JSONAllowPartialMessages(true),
+			csproto.JSONAllowUnknownFields(true),
+		}
+		err := csproto.JSONUnmarshaler(&msg, opts...).UnmarshalJSON(data)
+		assert.NoError(t, err, "JSON unmarshaling should not fail")
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+}
+
 func TestProto3GogoMarshalText(t *testing.T) {
 	msg := createTestProto3GogoMessage()
 	// replace the current date/time with a known value for reproducible output

--- a/example/proto3_googlev2_test.go
+++ b/example/proto3_googlev2_test.go
@@ -134,6 +134,97 @@ func TestProto3GoogleV2MarshalJSON(t *testing.T) {
 	})
 }
 
+func TestProto3GoogleV2UnmarshalJSON(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		ts := timestamppb.Now()
+		data := []byte(fmt.Sprintf(`{"name":"default","ts":"%s","eventType":"EVENT_TYPE_ONE"}`, genGoogleTimestampString(ts)))
+		var msg googlev2.EventUsingWKTs
+		expected := googlev2.EventUsingWKTs{
+			Name:      "default",
+			Ts:        ts,
+			EventType: googlev2.EventType_EVENT_TYPE_ONE,
+		}
+
+		err := csproto.JSONUnmarshaler(&msg).UnmarshalJSON(data)
+		assert.NoError(t, err)
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+	t.Run("with-unknown-fields", func(t *testing.T) {
+		ts := timestamppb.Now()
+		data := []byte(fmt.Sprintf(`{"name":"default","ts":"%s","eventType":"EVENT_TYPE_ONE","dfjaklds":"dfjklad"}`, genGoogleTimestampString(ts)))
+		var msg googlev2.EventUsingWKTs
+
+		err := csproto.JSONUnmarshaler(&msg).UnmarshalJSON(data)
+		assert.Error(t, err, "JSON unmarshaling should fail if there are unknown fields")
+	})
+	t.Run("allow-unknown-fields", func(t *testing.T) {
+		ts := timestamppb.Now()
+		data := []byte(fmt.Sprintf(`{"name":"default","ts":"%s","eventType":"EVENT_TYPE_ONE","dfjaklds":"dfjklad"}`, genGoogleTimestampString(ts)))
+		var msg googlev2.EventUsingWKTs
+		expected := googlev2.EventUsingWKTs{
+			Name:      "default",
+			Ts:        ts,
+			EventType: googlev2.EventType_EVENT_TYPE_ONE,
+		}
+
+		opts := []csproto.JSONOption{
+			csproto.JSONAllowUnknownFields(true),
+		}
+		err := csproto.JSONUnmarshaler(&msg, opts...).UnmarshalJSON(data)
+		assert.NoError(t, err)
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+	t.Run("with-missing-required-fields", func(t *testing.T) {
+		ts := timestamppb.Now()
+		data := []byte(fmt.Sprintf(`{"ts":"%s","eventType":"EVENT_TYPE_ONE"}`, genGoogleTimestampString(ts)))
+		var msg googlev2.EventUsingWKTs
+		expected := googlev2.EventUsingWKTs{
+			Name:      "", // name should not be set
+			Ts:        ts,
+			EventType: googlev2.EventType_EVENT_TYPE_ONE,
+		}
+
+		err := csproto.JSONUnmarshaler(&msg).UnmarshalJSON(data)
+		assert.NoError(t, err, "JSON unmarshaling should not fail since proto3 does not have required fields")
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+	t.Run("allow-partial", func(t *testing.T) {
+		ts := timestamppb.Now()
+		data := []byte(fmt.Sprintf(`{"ts":"%s","eventType":"EVENT_TYPE_ONE"}`, genGoogleTimestampString(ts)))
+		var msg googlev2.EventUsingWKTs
+		expected := googlev2.EventUsingWKTs{
+			Name:      "", // name should not be set
+			Ts:        ts,
+			EventType: googlev2.EventType_EVENT_TYPE_ONE,
+		}
+
+		opts := []csproto.JSONOption{
+			csproto.JSONAllowPartialMessages(true),
+		}
+		err := csproto.JSONUnmarshaler(&msg, opts...).UnmarshalJSON(data)
+		assert.NoError(t, err, "JSON unmarshaling should not fail since proto3 does not have required fields")
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+	t.Run("enable-all", func(t *testing.T) {
+		ts := timestamppb.Now()
+		data := []byte(fmt.Sprintf(`{"ts":"%s","eventType":"EVENT_TYPE_ONE","dfjaklds":"dfjklad"}`, genGoogleTimestampString(ts)))
+		var msg googlev2.EventUsingWKTs
+		expected := googlev2.EventUsingWKTs{
+			Name:      "", // name should not be set
+			Ts:        ts,
+			EventType: googlev2.EventType_EVENT_TYPE_ONE,
+		}
+
+		opts := []csproto.JSONOption{
+			csproto.JSONAllowPartialMessages(true),
+			csproto.JSONAllowUnknownFields(true),
+		}
+		err := csproto.JSONUnmarshaler(&msg, opts...).UnmarshalJSON(data)
+		assert.NoError(t, err, "JSON unmarshaling should not fail")
+		assert.True(t, csproto.Equal(&msg, &expected))
+	})
+}
+
 func TestProto3GoogleV2MarshalText(t *testing.T) {
 	msg := createTestProto3GoogleV2Message()
 	// replace the current date/time with a known value for reproducible output


### PR DESCRIPTION
- add exported functions for `EncodeFixed(32|64)` for completeness/consistency
- add API for JSON unmarshaling with associated tests