### PR TITLE
fix: use deducemsgType for MarshalJSON

### DIFF
--- a/json.go
+++ b/json.go
@@ -42,8 +42,7 @@ var _ json.Marshaler = (*jsonMarshaler)(nil)
 // this method calls the appropriate underlying runtime (Gogo vs Google V1 vs Google V2) based on
 // the message's actual type.
 func (m *jsonMarshaler) MarshalJSON() ([]byte, error) {
-	value := reflect.ValueOf(m.msg)
-	if m.msg == nil || value.IsNil() {
+	if m.msg == nil || reflect.ValueOf(m.msg).IsNil() {
 		return nil, nil
 	}
 
@@ -54,7 +53,7 @@ func (m *jsonMarshaler) MarshalJSON() ([]byte, error) {
 
 	var buf bytes.Buffer
 
-	msgType := deduceMsgType(m.msg, value.Type())
+	msgType := MsgType(m.msg)
 	switch msgType {
 	case MessageTypeGoogle:
 		mo := protojson.MarshalOptions{
@@ -87,9 +86,10 @@ func (m *jsonMarshaler) MarshalJSON() ([]byte, error) {
 			return nil, fmt.Errorf("unable to marshal message to JSON: %w", err)
 		}
 		return buf.Bytes(), nil
+	default:
+		return nil, fmt.Errorf("unsupported message type %T", m.msg)
 	}
 
-	return nil, fmt.Errorf("unsupported message type %T", m.msg)
 }
 
 // JSONUnmarshaler returns an implementation of the json.Unmarshaler interface that unmarshals a

--- a/message_types_test.go
+++ b/message_types_test.go
@@ -1,0 +1,71 @@
+package csproto
+
+import (
+	gogo "github.com/gogo/protobuf/proto"
+	googlev1 "github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
+	googlev2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"reflect"
+	"testing"
+)
+
+type GogoMessage struct{}
+
+func (m GogoMessage) Reset()         {}
+func (m GogoMessage) String() string { return "" }
+func (m GogoMessage) ProtoMessage()  {}
+
+var _ gogo.Message = &GogoMessage{}
+
+type GoogleV1Message struct{ Text string }
+
+func (m GoogleV1Message) Reset()         {}
+func (m GoogleV1Message) String() string { return "" }
+func (m GoogleV1Message) ProtoMessage()  {}
+
+var _ googlev1.Message = &GoogleV1Message{}
+
+type GoogleV2Message struct{}
+
+func (g GoogleV2Message) ProtoReflect() protoreflect.Message { return nil }
+
+var _ googlev2.Message = &GoogleV2Message{}
+
+func TestDeduceMsgType(t *testing.T) {
+	tt := []struct {
+		msgType MessageType
+		msg     interface{}
+		prepare func()
+	}{
+		{
+			msgType: MessageTypeGogo,
+			msg:     &GogoMessage{},
+			prepare: func() {
+				gogo.RegisterType(&GogoMessage{}, "test_message")
+			},
+		},
+		{
+			msgType: MessageTypeGoogleV1,
+			msg:     &GoogleV1Message{},
+		},
+		{
+			msgType: MessageTypeGoogle,
+			msg:     &GoogleV2Message{},
+		},
+		{
+			msgType: MessageTypeUnknown,
+			msg:     struct{}{},
+		},
+	}
+
+	for _, tc := range tt {
+		if tc.prepare != nil {
+			tc.prepare()
+		}
+		require.Equal(t,
+			tc.msgType,
+			deduceMsgType(tc.msg, reflect.TypeOf(tc.msg)),
+		)
+	}
+}


### PR DESCRIPTION
Previously `MarshalJSON` would determine the correct marshalling action, by asserting the given `interface{}` as specific interface implementations. Unfortunately, `googlev1.Message` and `goog.Message` have overlapping interface implementations and therefore the `MarshalJSON` function would never reach the `gogo.Message` case.

Fortunately, `deduceMsgType` already exists in the code base which addresses this issue, which solved the issue by using this function to determine the message type and then determining the following action via. a switch statement based on the output of `deduceMsgType`.