### PR TITLE
fix: avoid panic when decoding an invalid length-delimited field

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -140,6 +140,9 @@ func (d *Decoder) DecodeBytes() ([]byte, error) {
 	if n == 0 {
 		return nil, ErrInvalidVarintData
 	}
+	if d.offset+n+int(l) > len(d.p) {
+		return nil, io.ErrUnexpectedEOF
+	}
 	b := d.p[d.offset+n : d.offset+n+int(l)]
 	d.offset += n + int(l)
 	return b, nil


### PR DESCRIPTION
Adds a bounds check to `Decoder.DecodeBytes()` to return `io.ErrUnexpectedEOF` instead of panicking if the encoded data is shorter than the encoded length