### PR TITLE
Avoid panics when decoding invalid messages

### DIFF
--- a/example/proto2_gogo_test.go
+++ b/example/proto2_gogo_test.go
@@ -261,6 +261,16 @@ func TestProto2GogoClone(t *testing.T) {
 	assert.NotEqual(t, unsafe.Pointer(m1), unsafe.Pointer(m2))
 }
 
+func TestProto2GogoExtensionFieldNumber(t *testing.T) {
+	n, err := csproto.ExtensionFieldNumber(gogo.E_TestEvent_EventExt)
+	assert.Equal(t, 100, n, "extension field number should be 100")
+	assert.NoError(t, err)
+
+	n, err = csproto.ExtensionFieldNumber(37)
+	assert.Equal(t, 0, n, "field number should be 0 for invalid value")
+	assert.Error(t, err)
+}
+
 func createTestProto2GogoMessage() *gogo.BaseEvent {
 	now := uint64(time.Now().UTC().Unix())
 	et := gogo.EventType_EVENT_TYPE_ONE

--- a/example/proto2_googlev1_test.go
+++ b/example/proto2_googlev1_test.go
@@ -288,6 +288,12 @@ func TestProto2GoogleV1Clone(t *testing.T) {
 	assert.NotEqual(t, unsafe.Pointer(m1), unsafe.Pointer(m2))
 }
 
+func TestProto2GoogleExtensionFieldNumber(t *testing.T) {
+	n, err := csproto.ExtensionFieldNumber(googlev1.E_TestEvent_EventExt)
+	assert.Equal(t, 100, n, "extension field number should be 100")
+	assert.NoError(t, err)
+}
+
 func createTestProto2GoogleV1Message() *googlev1.BaseEvent {
 	now := uint64(time.Now().UTC().Unix())
 	et := googlev1.EventType_EVENT_TYPE_ONE

--- a/example/proto2_googlev2_test.go
+++ b/example/proto2_googlev2_test.go
@@ -288,6 +288,12 @@ func TestProto2GoogleV2Clone(t *testing.T) {
 	assert.NotEqual(t, unsafe.Pointer(m1), unsafe.Pointer(m2))
 }
 
+func TestProto2GoogleV2ExtensionFieldNumber(t *testing.T) {
+	n, err := csproto.ExtensionFieldNumber(googlev2.E_TestEvent_EventExt)
+	assert.Equal(t, 100, n, "extension field number should be 100")
+	assert.NoError(t, err)
+}
+
 func createTestProto2GoogleV2Message() *googlev2.BaseEvent {
 	now := uint64(time.Now().UTC().Unix())
 	et := googlev2.EventType_EVENT_TYPE_ONE

--- a/extensions.go
+++ b/extensions.go
@@ -199,7 +199,7 @@ func ExtensionFieldNumber(ext any) (int, error) {
 	case *gogo.ExtensionDesc:
 		return int(tv.Field), nil
 	case *google.ExtensionDesc:
-		return int(tv.Field), nil
+		return int(tv.TypeDescriptor().Number()), nil
 	case protoreflect.ExtensionType:
 		return int(tv.TypeDescriptor().Number()), nil
 	default:


### PR DESCRIPTION
This PR adds bounds checks to all paths in `Decoder` to avoid panics when attempting to decode invalid/corrupt Protobuf messages.  The changes had a minimal impact on benchmarks, so the general safety is a net win.

I also addressed a new linter warning that was introduced in v0.15.0 and added unit tests for the `ExtensionFieldNumber(any) int` function