### PR TITLE
Fix panic after decoding msg with invalid unknown fields

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,3 +54,6 @@ jobs:
 
       - name: protoc-gen-fastmarshal
         run: go build ./cmd/protoc-gen-fastmarshal
+
+      - name: protodump
+        run: go build ./cmd/protodump

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,29 @@ builds:
     binary: protoc-gen-fastmarshal
     flags:
       - -trimpath
+    ldflags:
+      - '-X main.version={{.Version}} -X main.commit={{.FullCommit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser'
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - '386'
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - '6'
+      - '7'
+    goos:
+      - linux
+      - darwin
+      - windows
+  - id: protodump
+    main: ./cmd/protodump
+    binary: protodump
+    flags:
+      - -trimpath
+    ldflags:
+      - '-X main.version={{.Version}} -X main.commit={{.FullCommit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser'
     env:
       - CGO_ENABLED=0
     goarch:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,12 +46,12 @@ builds:
       - darwin
       - windows
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip

--- a/cmd/protodump/main.go
+++ b/cmd/protodump/main.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/CrowdStrike/csproto"
+)
+
+func main() {
+	var (
+		inputFile       string
+		expandPaths     tagPaths
+		stringPaths     tagPaths
+		showVersionInfo bool
+		showUsage       bool
+	)
+
+	fset := flag.NewFlagSet("protodump", flag.ExitOnError)
+	fset.Usage = printUsage(fset)
+	fset.StringVar(&inputFile, "file", "", "The path to the Protobuf data to be decoded. (optional, reads from stdin if not specified)")
+	fset.Var(&expandPaths, "expand", "One or more 'paths' to length-delimited fields in the message that should be expanded (optional)")
+	fset.Var(&stringPaths, "strings", "One or more 'paths' to length-delimited fields in the message that contain string data (optional)")
+	fset.BoolVar(&showVersionInfo, "version", false, "Shows version information")
+	fset.BoolVar(&showUsage, "help", false, "Shows usage information")
+
+	err := fset.Parse(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if showUsage {
+		fset.Usage()
+		return
+	}
+
+	if showVersionInfo {
+		echoVersion()
+		return
+	}
+
+	var (
+		f *os.File
+	)
+	if inputFile != "" {
+		f, err = os.Open(filepath.Clean(inputFile))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to open input file %q: %v\n", inputFile, err)
+			os.Exit(1)
+		}
+		defer f.Close()
+	} else {
+		var fi os.FileInfo
+		f = os.Stdin
+		fi, err = f.Stat()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unexpected error: %v\n", err)
+			os.Exit(1)
+		}
+		if fi.Size() == 0 {
+			fmt.Fprintln(os.Stderr, "No data provided on stdin.  Use '-file' or pass data on stdin.")
+			os.Exit(1)
+		}
+	}
+	err = dumpProtoFile(f, &expandPaths, &stringPaths)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+const usageMsg = `protodump - A simple Protobuf binary message decoder
+
+Outputs tag/wire type information, along with values where possible, for binary Protobuf messages.
+The message data can be passed in via stdin or using the '-file' command-line flag.
+
+Two additional options are supported for length-delimited fields.  For nested message fields, the
+'-expand' flag can be used to "recurse" into those messages.  The '-strings' flag can be used to output
+field values as strings instead of raw bytes.  Both parameters accept one or more "tag path" values,
+which are dot-separated lists of integer field tags that indicate the nesting structure of the message
+data.
+
+Examples:
+	cat message.bin | protodump
+	protodump -file message.bin
+	protodump -file message.bin -expand "3" -expand "4.4" -strings "1,2,3.1,3.2`
+
+func printUsage(fset *flag.FlagSet) func() {
+	return func() {
+		fmt.Fprintln(os.Stderr, usageMsg)
+		fmt.Fprintln(os.Stderr, "\n\nFlags:")
+		fset.PrintDefaults()
+	}
+}
+
+var (
+	version = ""
+	commit  = "unknown"
+	date    = "unknown"
+	builtBy = "unknown"
+)
+
+func echoVersion() {
+	if version == "" {
+		info, ok := debug.ReadBuildInfo()
+		if ok {
+			fmt.Printf("%v\n", info)
+			version = info.Main.Version
+			for _, s := range info.Settings {
+				switch s.Key {
+				case "vcs.revision":
+					commit = s.Value
+				case "vcs.time":
+					date = s.Value
+				}
+			}
+			if version == "(devel)" && commit != "unknown" && date != "unknown" {
+				ts, err := time.Parse(time.RFC3339, date)
+				if err != nil {
+					ts = time.Now().UTC()
+				}
+				shortHash := commit
+				if len(shortHash) > 12 {
+					shortHash = shortHash[:12]
+				}
+				version = fmt.Sprintf("v0.0.0-devel-%s-%s", ts.Format("20060102130607"), shortHash)
+			}
+		}
+	}
+	fmt.Printf("version: %s\ncommit:  %s\ndate:    %s\nbuiltBy: %s\n", version, commit, date, builtBy)
+}
+
+func dumpProtoFile(input io.Reader, expand *tagPaths, stringPaths *tagPaths) error {
+	data, err := io.ReadAll(input)
+	if err != nil {
+		return err
+	}
+	conf := dumpConfig{
+		indent:  0,
+		expand:  expand,
+		strings: stringPaths,
+	}
+	return dumpProto(os.Stdout, csproto.NewDecoder(data), tagPath{}, conf)
+}
+
+type tagPathMatcher interface {
+	Matches(tagPath) bool
+}
+
+type dumpConfig struct {
+	indent  int
+	expand  tagPathMatcher
+	strings tagPathMatcher
+}
+
+func (conf dumpConfig) isStringField(tp tagPath) bool {
+	return conf.strings.Matches(tp)
+}
+
+func (conf dumpConfig) shouldExpand(tp tagPath) bool {
+	return conf.expand.Matches(tp)
+}
+
+func dumpProto(w io.Writer, dec *csproto.Decoder, parentTagPath tagPath, conf dumpConfig) error {
+	prefix := strings.Repeat(" ", 2*conf.indent)
+	bw := bufio.NewWriter(w)
+	defer bw.Flush()
+
+	for dec.More() {
+		tag, wireType, err := dec.DecodeTag()
+		if err != nil {
+			return err
+		}
+
+		thisTagPath := append(parentTagPath, tag)
+
+		bw.WriteString(fmt.Sprintf("%stag: %d, wire type: %s\n", prefix, tag, wireType))
+		switch wireType {
+		case csproto.WireTypeVarint:
+			vv, err := dec.DecodeInt64()
+			if err != nil {
+				return err
+			}
+			bw.WriteString(fmt.Sprintf("%s  varint: %d\n", prefix, vv))
+		case csproto.WireTypeFixed32:
+			f32, err := dec.DecodeFixed32()
+			if err != nil {
+				return err
+			}
+			bw.WriteString(fmt.Sprintf("%s  fixed32: %d\n", prefix, f32))
+		case csproto.WireTypeFixed64:
+			f64, err := dec.DecodeFixed64()
+			if err != nil {
+				return err
+			}
+			bw.WriteString(fmt.Sprintf("%s  fixed64: %d\n", prefix, f64))
+		case csproto.WireTypeLengthDelimited:
+			ldv, err := dec.DecodeBytes()
+			if err != nil {
+				return err
+			}
+			bw.WriteString(fmt.Sprintf("%s  length: %d\n", prefix, len(ldv)))
+			switch {
+			case conf.isStringField(thisTagPath):
+				bw.WriteString(fmt.Sprintf("%s  string: %s\n", prefix, string(ldv)))
+			default:
+				bw.WriteString(fmt.Sprintf("%s  [", prefix))
+				for i, b := range ldv {
+					if i > 0 {
+						bw.WriteRune(',')
+					}
+					bw.WriteString(fmt.Sprintf("0x%02X", b))
+				}
+				bw.WriteString("]\n")
+				if conf.shouldExpand(thisTagPath) {
+					bw.Flush()
+					conf.indent++
+					err = dumpProto(w, csproto.NewDecoder(ldv), thisTagPath, conf)
+					conf.indent--
+					if err != nil {
+						return err
+					}
+				}
+			}
+		default:
+			dec.Skip(tag, wireType)
+			return fmt.Errorf("unrecognized proto wire type (%d)", int(wireType))
+		}
+	}
+	return nil
+}

--- a/cmd/protodump/main.go
+++ b/cmd/protodump/main.go
@@ -182,46 +182,46 @@ func dumpProto(w io.Writer, dec *csproto.Decoder, parentTagPath tagPath, conf du
 
 		thisTagPath := append(parentTagPath, tag)
 
-		bw.WriteString(fmt.Sprintf("%stag: %d, wire type: %s\n", prefix, tag, wireType))
+		_, _ = bw.WriteString(fmt.Sprintf("%stag: %d, wire type: %s\n", prefix, tag, wireType))
 		switch wireType {
 		case csproto.WireTypeVarint:
 			vv, err := dec.DecodeInt64()
 			if err != nil {
 				return err
 			}
-			bw.WriteString(fmt.Sprintf("%s  varint: %d\n", prefix, vv))
+			_, _ = bw.WriteString(fmt.Sprintf("%s  varint: %d\n", prefix, vv))
 		case csproto.WireTypeFixed32:
 			f32, err := dec.DecodeFixed32()
 			if err != nil {
 				return err
 			}
-			bw.WriteString(fmt.Sprintf("%s  fixed32: %d\n", prefix, f32))
+			_, _ = bw.WriteString(fmt.Sprintf("%s  fixed32: %d\n", prefix, f32))
 		case csproto.WireTypeFixed64:
 			f64, err := dec.DecodeFixed64()
 			if err != nil {
 				return err
 			}
-			bw.WriteString(fmt.Sprintf("%s  fixed64: %d\n", prefix, f64))
+			_, _ = bw.WriteString(fmt.Sprintf("%s  fixed64: %d\n", prefix, f64))
 		case csproto.WireTypeLengthDelimited:
 			ldv, err := dec.DecodeBytes()
 			if err != nil {
 				return err
 			}
-			bw.WriteString(fmt.Sprintf("%s  length: %d\n", prefix, len(ldv)))
+			_, _ = bw.WriteString(fmt.Sprintf("%s  length: %d\n", prefix, len(ldv)))
 			switch {
 			case conf.isStringField(thisTagPath):
-				bw.WriteString(fmt.Sprintf("%s  string: %s\n", prefix, string(ldv)))
+				_, _ = bw.WriteString(fmt.Sprintf("%s  string: %s\n", prefix, string(ldv)))
 			default:
-				bw.WriteString(fmt.Sprintf("%s  [", prefix))
+				_, _ = bw.WriteString(fmt.Sprintf("%s  [", prefix))
 				for i, b := range ldv {
 					if i > 0 {
-						bw.WriteRune(',')
+						_, _ = bw.WriteRune(',')
 					}
-					bw.WriteString(fmt.Sprintf("0x%02X", b))
+					_, _ = bw.WriteString(fmt.Sprintf("0x%02X", b))
 				}
-				bw.WriteString("]\n")
+				_, _ = bw.WriteString("]\n")
 				if conf.shouldExpand(thisTagPath) {
-					bw.Flush()
+					_ = bw.Flush()
 					conf.indent++
 					err = dumpProto(w, csproto.NewDecoder(ldv), thisTagPath, conf)
 					conf.indent--
@@ -231,7 +231,7 @@ func dumpProto(w io.Writer, dec *csproto.Decoder, parentTagPath tagPath, conf du
 				}
 			}
 		default:
-			dec.Skip(tag, wireType)
+			_, _ = dec.Skip(tag, wireType)
 			return fmt.Errorf("unrecognized proto wire type (%d)", int(wireType))
 		}
 	}

--- a/cmd/protodump/tagpath.go
+++ b/cmd/protodump/tagpath.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/CrowdStrike/csproto"
+)
+
+// tagPath defines a list of integer values that represent a "path" to a particular field in a binary
+// Protobuf message.  Integers are used because encoded Protobuf messages do not contain field names,
+// only the integer tags defined in the .proto IDL.
+//
+// Each element in the path represents a field at that level of the encoded message.  A value of 0 is
+// used to indicate that the path applies to all fields at that level.
+//
+// The path "1" refereces the Outer.id field in the example Protobuf IDL below.  Similarly, the path
+// "3.2" references the Inner.timestamp field inside of Outer.nested.
+//
+//	message Outer {
+//		int32 id      = 1;
+//		string name   = 2;
+//		Inner nested = 3;
+//	}
+//	message Inner {
+//		int32 id        = 1;
+//		int64 timestamp = 2;
+//	}
+type tagPath []int
+
+// String returns a string representation of this path.
+func (tp tagPath) String() string {
+	if len(tp) == 0 {
+		return ""
+	}
+	ss := make([]string, len(tp))
+	for i, t := range tp {
+		ss[i] = strconv.Itoa(t)
+	}
+	return strings.Join(ss, ".")
+}
+
+// Matches accepts a tag path and returns a boolean value indicating whether or not this path refers
+// to the same field as p.
+func (tp tagPath) Matches(p tagPath) bool {
+	if len(tp) == 0 || len(tp) != len(p) {
+		return false
+	}
+	for i, t := range tp {
+		if t != p[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// tagPaths defines a custom flag.Value implementation for a flag that can store one or more Protobuf
+// tag "paths".
+type tagPaths struct {
+	paths []tagPath
+}
+
+// String returns a string representation of the current value.
+func (v *tagPaths) String() string {
+	if len(v.paths) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	for i, p := range v.paths {
+		if i > 0 {
+			sb.WriteRune(',')
+		}
+		for j, tag := range p {
+			if j > 0 {
+				sb.WriteRune('.')
+			}
+			sb.WriteString(strconv.Itoa(tag))
+		}
+	}
+	s := sb.String()
+	return "[" + s + "]"
+}
+
+// Set satisfies the [flag.Value] interface and parses the provided string into a list of one or more
+// tag paths and appends them to the stored value.
+func (v *tagPaths) Set(value string) error {
+	if value == "" {
+		return nil
+	}
+	paths := strings.Split(value, ",")
+	for _, p := range paths {
+		var thisPath tagPath
+		tokens := strings.Split(p, ".")
+		for _, t := range tokens {
+			tag, err := strconv.Atoi(t)
+			if err != nil {
+				return fmt.Errorf("invalid tag token, must be a positive integer or \"*\"")
+			}
+			if tag < 0 || tag > csproto.MaxTagValue {
+				return fmt.Errorf("invalid protobuf tag value: %d", tag)
+			}
+			thisPath = append(thisPath, tag)
+		}
+		v.paths = append(v.paths, thisPath)
+	}
+	return nil
+}
+
+// ShouldExpand takes a tagPath and returns a boolean value indicating if that path is in the stored list
+func (v *tagPaths) ShouldExpand(p tagPath) bool {
+	for _, pp := range v.paths {
+		if pp.Matches(p) {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *tagPaths) Matches(p tagPath) bool {
+	for _, pp := range v.paths {
+		if pp.Matches(p) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/protodump/tagpath.go
+++ b/cmd/protodump/tagpath.go
@@ -94,16 +94,21 @@ func (v *tagPaths) Set(value string) error {
 		var thisPath tagPath
 		tokens := strings.Split(p, ".")
 		for _, t := range tokens {
+			if t == "" {
+				continue
+			}
 			tag, err := strconv.Atoi(t)
 			if err != nil {
-				return fmt.Errorf("invalid tag token, must be a positive integer or \"*\"")
+				return fmt.Errorf("invalid tag token %q, must be a valid integer Protobuf field tag", t)
 			}
 			if tag < 0 || tag > csproto.MaxTagValue {
 				return fmt.Errorf("invalid protobuf tag value: %d", tag)
 			}
 			thisPath = append(thisPath, tag)
 		}
-		v.paths = append(v.paths, thisPath)
+		if len(thisPath) > 0 {
+			v.paths = append(v.paths, thisPath)
+		}
 	}
 	return nil
 }

--- a/cmd/protodump/tagpath_test.go
+++ b/cmd/protodump/tagpath_test.go
@@ -1,10 +1,36 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/CrowdStrike/csproto"
 )
+
+func Example_tagPaths() {
+	// This example covers using a tagPaths variable with the standard library flag package
+	// to parse tag paths from the command line.
+
+	// declare and register the flag value
+	var tp tagPaths
+	fset := flag.NewFlagSet("test", flag.ExitOnError)
+	fset.Var(&tp, "paths", "")
+
+	// parse the "command line"
+	// - in real code this would be fset.Parse(os.Args[1:])
+	err := fset.Parse([]string{"-paths", "1,2,3", "-paths", "1.2", "-paths", "3.4", "-paths", "5.6"})
+	if err != nil {
+		fmt.Printf("error parsing args: %v\n", err)
+	}
+
+	// should have parsed 6 values, 3 from the first -paths param and 1 each from the other 3
+	fmt.Printf("results: %s", tp.String())
+	// Output: results: [1,2,3,1.2,3.4,5.6]
+}
 
 func TestTagPathArgParse(t *testing.T) {
 	t.Parallel()
@@ -14,11 +40,23 @@ func TestTagPathArgParse(t *testing.T) {
 		shouldFail bool
 		expected   []tagPath
 	}{
+		// success cases
 		{"empty", "", false, nil},
 		{"single value", "1", false, []tagPath{{1}}},
 		{"multiple single values", "1,2", false, []tagPath{{1}, {2}}},
 		{"single dotted value", "1.2", false, []tagPath{{1, 2}}},
 		{"multiple dotted values", "1.2,3.4", false, []tagPath{{1, 2}, {3, 4}}},
+		// failure cases
+		{"single non-integer value", "x", true, nil},
+		{"single non-integer dotted value", "1.x", true, nil},
+		{"multiple single values with non-integer", "1,2,x", true, nil},
+		{"multiple dotted values with non-integer", "1.2,3.4,5.x", true, nil},
+		{"invalid integer value/underflow", "-1", true, nil},
+		{"invalid integer value/overflow", strconv.Itoa(csproto.MaxTagValue + 1), true, nil},
+		// edge cases
+		{"leading comma", ",1,2,3", false, []tagPath{{1}, {2}, {3}}},
+		{"trailing comma", "1,2,3,", false, []tagPath{{1}, {2}, {3}}},
+		{"multiple values with empty item", "1,,2.3", false, []tagPath{{1}, {2, 3}}},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -32,8 +70,8 @@ func TestTagPathArgParse(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, ev.paths, "argument parsing incorrect")
 			}
-			assert.Equal(t, tc.expected, ev.paths, "argument parsing incorrect")
 		})
 	}
 }

--- a/cmd/protodump/tagpath_test.go
+++ b/cmd/protodump/tagpath_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagPathArgParse(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		input      string
+		shouldFail bool
+		expected   []tagPath
+	}{
+		{"empty", "", false, nil},
+		{"single value", "1", false, []tagPath{{1}}},
+		{"multiple single values", "1,2", false, []tagPath{{1}, {2}}},
+		{"single dotted value", "1.2", false, []tagPath{{1, 2}}},
+		{"multiple dotted values", "1.2,3.4", false, []tagPath{{1, 2}, {3, 4}}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var ev tagPaths
+			err := ev.Set(tc.input)
+
+			if tc.shouldFail {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expected, ev.paths, "argument parsing incorrect")
+		})
+	}
+}
+
+func TestTagPathMatch(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		tp          tagPath
+		against     tagPath
+		shouldMatch bool
+	}{
+		{
+			name:        "empty path does not match empty path",
+			tp:          tagPath{},
+			against:     tagPath{},
+			shouldMatch: false,
+		},
+		{
+			name:        "empty path does not match non-empty path",
+			tp:          tagPath{},
+			against:     tagPath{1},
+			shouldMatch: false,
+		},
+		{
+			name:        "non-empty path does not match longer path",
+			tp:          tagPath{1},
+			against:     tagPath{1, 2},
+			shouldMatch: false,
+		},
+		{
+			name:        "non-empty path does not match shorter path",
+			tp:          tagPath{1, 2},
+			against:     tagPath{1},
+			shouldMatch: false,
+		},
+		{
+			name:        "mismatched path does not match",
+			tp:          tagPath{1, 2, 3, 4},
+			against:     tagPath{1, 2, 3, 5},
+			shouldMatch: false,
+		},
+		{
+			name:        "single node path matches",
+			tp:          tagPath{1},
+			against:     tagPath{1},
+			shouldMatch: true,
+		},
+		{
+			name:        "multiple node path matches",
+			tp:          tagPath{1, 2, 3},
+			against:     tagPath{1, 2, 3},
+			shouldMatch: true,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.tp.Matches(tc.against)
+			assert.Equal(t, tc.shouldMatch, got)
+		})
+	}
+}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1192,6 +1192,8 @@ func FuzzDecodeTag(f *testing.F) {
 				// valid error
 			case errors.Is(err, csproto.ErrInvalidVarintData):
 				// valid error
+			case errors.Is(err, csproto.ErrInvalidFieldTag):
+				// valid error
 			default:
 				t.Errorf("unexpected error from DecodeTag(): %v", err)
 			}


### PR DESCRIPTION
This PR addresses a panic when calling `.String()` on a decoded message struct when the encoded message contained unknown/unrecognized data that is not a valid encoded field value.  The specific case that exposed this was an internal message that had 6 extra zero bytes after a `google.protobuf.Timestamp` field.  Those extra bytes got copied to the `unknownFields` field on the Go struct.

Google's runtime implementation returns an error for the same data so the "fix" was to update `Decoder` to also return an error.  This is potentially a breaking change because the prior code did not return an error.

While troubleshooting this issue, I also wrote a new `protodump` CLI that can decode a binary message and output basic tag/wire type info without depending on the Protobuf file descriptor.  I added that tool the repo and we now include it in the published binary artifacts for each release.

Additionally, the Goreleaser config has been updated to include version information in the generated binaries.