### PR TITLE
fix: RangeExtensions doesn't enumerate all items for Google V2

### DIFF
--- a/example/proto2_gogo_test.go
+++ b/example/proto2_gogo_test.go
@@ -285,6 +285,35 @@ func TestProto2GogoExtensions(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestProto2GogoRangeExtensions(t *testing.T) {
+	m := createTestProto2GogoMessage()
+	t.Run("enumerate all", func(t *testing.T) {
+		nCalls := 0
+		err := csproto.RangeExtensions(m, func(value interface{}, name string, field int32) error {
+			t.Logf("name=%s, field=%d, value=%v", name, field, value)
+			nCalls++
+			return nil
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, nCalls, "range callback should have been called 1 time")
+	})
+	t.Run("enumeration error", func(t *testing.T) {
+		var (
+			testErr = fmt.Errorf("something went wrong")
+			nCalls  = 0
+		)
+		err := csproto.RangeExtensions(m, func(value interface{}, name string, field int32) error {
+			nCalls++
+			return testErr
+		})
+
+		assert.Error(t, err)
+		assert.Equal(t, testErr, err)
+		assert.Equal(t, 1, nCalls, "range callback should have been called 1 time")
+	})
+}
+
 func createTestProto2GogoMessage() *gogo.BaseEvent {
 	now := uint64(time.Now().UTC().Unix())
 	et := gogo.EventType_EVENT_TYPE_ONE

--- a/example/proto2_googlev1_test.go
+++ b/example/proto2_googlev1_test.go
@@ -294,6 +294,35 @@ func TestProto2GoogleExtensionFieldNumber(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestProto2GoogleV1RangeExtensions(t *testing.T) {
+	m := createTestProto2GoogleV1Message()
+	t.Run("enumerate all", func(t *testing.T) {
+		nCalls := 0
+		err := csproto.RangeExtensions(m, func(value interface{}, name string, field int32) error {
+			t.Logf("name=%s, field=%d, value=%v", name, field, value)
+			nCalls++
+			return nil
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, nCalls, "range callback should have been called 1 time")
+	})
+	t.Run("enumeration error", func(t *testing.T) {
+		var (
+			testErr = fmt.Errorf("something went wrong")
+			nCalls  = 0
+		)
+		err := csproto.RangeExtensions(m, func(value interface{}, name string, field int32) error {
+			nCalls++
+			return testErr
+		})
+
+		assert.Error(t, err)
+		assert.Equal(t, testErr, err)
+		assert.Equal(t, 1, nCalls, "range callback should have been called 1 time")
+	})
+}
+
 func createTestProto2GoogleV1Message() *googlev1.BaseEvent {
 	now := uint64(time.Now().UTC().Unix())
 	et := googlev1.EventType_EVENT_TYPE_ONE

--- a/example/proto2_googlev2_test.go
+++ b/example/proto2_googlev2_test.go
@@ -303,6 +303,35 @@ func TestProto2GoogleV2Extensions(t *testing.T) {
 	assert.Nil(t, ext)
 }
 
+func TestProto2GoogleV2RangeExtensions(t *testing.T) {
+	m := createTestProto2GoogleV2Message()
+	t.Run("enumerate all", func(t *testing.T) {
+		nCalls := 0
+		err := csproto.RangeExtensions(m, func(value interface{}, name string, field int32) error {
+			t.Logf("name=%s, field=%d, value=%v", name, field, value)
+			nCalls++
+			return nil
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, nCalls, "range callback should have been called 1 time")
+	})
+	t.Run("enumeration error", func(t *testing.T) {
+		var (
+			testErr = fmt.Errorf("something went wrong")
+			nCalls  = 0
+		)
+		err := csproto.RangeExtensions(m, func(value interface{}, name string, field int32) error {
+			nCalls++
+			return testErr
+		})
+
+		assert.Error(t, err)
+		assert.Equal(t, testErr, err)
+		assert.Equal(t, 1, nCalls, "range callback should have been called 1 time")
+	})
+}
+
 func createTestProto2GoogleV2Message() *googlev2.BaseEvent {
 	now := uint64(time.Now().UTC().Unix())
 	et := googlev2.EventType_EVENT_TYPE_ONE

--- a/extensions.go
+++ b/extensions.go
@@ -49,7 +49,7 @@ func RangeExtensions(msg interface{}, fn func(value interface{}, name string, fi
 				string(t.TypeDescriptor().FullName()),
 				int32(t.TypeDescriptor().Descriptor().Number()),
 			)
-			return err != nil
+			return err == nil
 		})
 		return err
 	case MessageTypeUnknown:


### PR DESCRIPTION
The Google V2 `RangeExtensions` API takes a callback that returns `bool` instead of `error` and we were returning `err != nil`, which returns `false` if there was no error and exits the enumeration.

This PR fixes the logic and adds unit tests for all three supported runtimes.