### PR TITLE
fix(protoc-gen-fastmarshal): generated code should respect Go package aliases from 'option go_package'

### DIFF
--- a/cmd/protoc-gen-fastmarshal/generator.go
+++ b/cmd/protoc-gen-fastmarshal/generator.go
@@ -38,7 +38,11 @@ func generateSingle(plugin *protogen.Plugin, req generateRequest) error {
 		name, content string
 		err           error
 	)
-	funcs := codeGenFunctions(req.ProtoDesc, req.SpecialNames)
+	goPackageForFile := make(map[string]string, len(plugin.Files))
+	for _, f := range plugin.Files {
+		goPackageForFile[f.Desc.Path()] = string(f.GoPackageName)
+	}
+	funcs := codeGenFunctions(req.ProtoDesc, req.SpecialNames, goPackageForFile)
 	for k, v := range req.Funcs {
 		funcs[k] = v
 	}
@@ -77,7 +81,11 @@ func generatePerMessage(plugin *protogen.Plugin, req generateRequest) error {
 		EnableUnsafeDecode bool
 	}
 
-	funcs := codeGenFunctions(req.ProtoDesc, req.SpecialNames)
+	goPackageForFile := make(map[string]string, len(plugin.Files))
+	for _, f := range plugin.Files {
+		goPackageForFile[f.Desc.Path()] = string(f.GoPackageName)
+	}
+	funcs := codeGenFunctions(req.ProtoDesc, req.SpecialNames, goPackageForFile)
 	for k, v := range req.Funcs {
 		funcs[k] = v
 	}

--- a/cmd/protoc-gen-fastmarshal/templates/permessage.go.tmpl
+++ b/cmd/protoc-gen-fastmarshal/templates/permessage.go.tmpl
@@ -12,7 +12,7 @@ import (
     "strings"{{end}}
     "sync/atomic"
     "github.com/CrowdStrike/csproto"
-    {{range (.Message | getAdditionalImports)}}{{.}}
+    {{range $path, $alias := (.Message | getAdditionalImports)}}{{ (printf "%s %s" $alias $path) | trimspace}}
     {{end}}
 )
 

--- a/cmd/protoc-gen-fastmarshal/templates/singlefile.go.tmpl
+++ b/cmd/protoc-gen-fastmarshal/templates/singlefile.go.tmpl
@@ -12,7 +12,7 @@ import (
     "strings"{{end}}
     "sync/atomic"
     "github.com/CrowdStrike/csproto"
-    {{range (allMessages | getAdditionalImports)}}{{.}}
+    {{range $path, $alias := (allMessages | getAdditionalImports)}}{{ (printf "%s %s" $alias $path) | trimspace}}
     {{end}}
 )
 

--- a/example/permessage/gogo/gogo_permessage_example_testevent.pb.fm.go
+++ b/example/permessage/gogo/gogo_permessage_example_testevent.pb.fm.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
-	"github.com/gogo/protobuf/types"
+	types "github.com/gogo/protobuf/types"
 )
 
 //------------------------------------------------------------------------------

--- a/example/proto2/gogo/gogo_proto2_example.pb.fm.go
+++ b/example/proto2/gogo/gogo_proto2_example.pb.fm.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
-	"github.com/gogo/protobuf/types"
+	types "github.com/gogo/protobuf/types"
 )
 
 //------------------------------------------------------------------------------

--- a/example/proto2/googlev1/googlev1_proto2_example.pb.fm.go
+++ b/example/proto2/googlev1/googlev1_proto2_example.pb.fm.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
-	"google.golang.org/protobuf/types/known/timestamppb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 //------------------------------------------------------------------------------

--- a/example/proto2/googlev2/googlev2_proto2_example.pb.fm.go
+++ b/example/proto2/googlev2/googlev2_proto2_example.pb.fm.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
-	"google.golang.org/protobuf/types/known/timestamppb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 //------------------------------------------------------------------------------

--- a/example/proto3/gogo/gogo_proto3_example.pb.fm.go
+++ b/example/proto3/gogo/gogo_proto3_example.pb.fm.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
-	"github.com/gogo/protobuf/types"
+	types "github.com/gogo/protobuf/types"
 )
 
 //------------------------------------------------------------------------------

--- a/example/proto3/googlev1/googlev1_proto3_example.pb.fm.go
+++ b/example/proto3/googlev1/googlev1_proto3_example.pb.fm.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
-	"google.golang.org/protobuf/types/known/structpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
+	structpb "google.golang.org/protobuf/types/known/structpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 //------------------------------------------------------------------------------

--- a/example/proto3/googlev2/googlev2_proto3_example.pb.fm.go
+++ b/example/proto3/googlev2/googlev2_proto3_example.pb.fm.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"sync/atomic"
 	"github.com/CrowdStrike/csproto"
-	"google.golang.org/protobuf/types/known/structpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
+	structpb "google.golang.org/protobuf/types/known/structpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Updates the logic that generates additional imports to extract the `go_package` option from the parent .proto file and include the explicit package name, if present update the codegen templates to use the package alias if set

Fixes #121