### PR TITLE
fix: Resolve panic in `Decoder.Skip()` with corrupt message

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,18 @@ run:
   modules-download-mode: readonly
   deadline: 10m
   timeout: 10m
-  skip-files:
-    - ".*\\.pb.*\\.go"
-    - ".*_test\\.go"
+
+issues:
+  exclude-rules:
+    # ignore code duplication in tests
+    - path: _test\.go
+      linters:
+        - dupl
+    # ignore deprecation warnings for golang/protobuf
+    - path: \.go
+      linters:
+        - staticcheck
+      text: '"github.com/golang/protobuf/proto" is deprecated'
 
 # output configuration options
 output:

--- a/example/proto2_gogo_test.go
+++ b/example/proto2_gogo_test.go
@@ -135,7 +135,7 @@ func TestProto2GogoMarshalJSON(t *testing.T) {
 			Name:      csproto.String("enable-all"),
 			EventType: &etype,
 		}
-		expected := fmt.Sprintf("{\n  \"eventType\":0,\"name\":\"enable-all\",\n  \"ts\":null\n}")
+		expected := "{\n  \"eventType\":0,\"name\":\"enable-all\",\n  \"ts\":null\n}"
 
 		opts := []csproto.JSONOption{
 			csproto.JSONIndent("  "),
@@ -233,7 +233,29 @@ func TestProto2GogoMarshalText(t *testing.T) {
 	// - this string matches gogo/protobuf@v1.3.2
 	// - if this test breaks after updating gogo/protobuf, then update the expected string
 	//   accordingly
-	expected := "eventID: \"test-event\"\nsourceID: \"test-source\"\ntimestamp: 946688523\neventType: EVENT_TYPE_ONE\ndata: \"\"\n[crowdstrike.csproto.example.proto2.gogo.TestEvent.eventExt]: <\n  name: \"test\"\n  info: \"\"\n  labels: \"one\"\n  labels: \"two\"\n  labels: \"three\"\n  embedded: <\n    ID: 42\n    stuff: \"some stuff\"\n    favoriteNumbers: 42\n    favoriteNumbers: 1138\n  >\n  jedi: true\n  nested: <\n    details: \"these are some nested details\"\n  >\n>\n"
+	expected := `eventID: "test-event"
+sourceID: "test-source"
+timestamp: 946688523
+eventType: EVENT_TYPE_ONE
+data: ""
+[crowdstrike.csproto.example.proto2.gogo.TestEvent.eventExt]: <
+  name: "test"
+  info: ""
+  labels: "one"
+  labels: "two"
+  labels: "three"
+  embedded: <
+    ID: 42
+    stuff: "some stuff"
+    favoriteNumbers: 42
+    favoriteNumbers: 1138
+  >
+  jedi: true
+  nested: <
+    details: "these are some nested details"
+  >
+>
+`
 
 	s, err := csproto.MarshalText(msg)
 

--- a/example/proto2_googlev1_test.go
+++ b/example/proto2_googlev1_test.go
@@ -145,7 +145,7 @@ func TestProto2GoogleV1MarshalJSON(t *testing.T) {
 			Name:      csproto.String("enable-all"),
 			EventType: &etype,
 		}
-		expected := fmt.Sprintf("{\n  \"eventType\":0,\"name\":\"enable-all\",\n  \"ts\":null\n}")
+		expected := "{\n  \"eventType\":0,\"name\":\"enable-all\",\n  \"ts\":null\n}"
 
 		opts := []csproto.JSONOption{
 			csproto.JSONIndent("  "),
@@ -257,7 +257,29 @@ func TestProto2GoogleV1MarshalText(t *testing.T) {
 	// - this string matches github.com/golang/protobuf@v1.5.2
 	// - if this test breaks after updating golang/protobuf, then update the expected string
 	//   accordingly
-	expected := "eventID: \"test-event\"\nsourceID: \"test-source\"\ntimestamp: 946688523\neventType: EVENT_TYPE_ONE\ndata: \"\"\n[crowdstrike.csproto.example.proto2.googlev1.TestEvent.eventExt]: {\n  name: \"test\"\n  info: \"\"\n  labels: \"one\"\n  labels: \"two\"\n  labels: \"three\"\n  embedded: {\n    ID: 42\n    stuff: \"some stuff\"\n    favoriteNumbers: 42\n    favoriteNumbers: 1138\n  }\n  jedi: true\n  nested: {\n    details: \"these are some nested details\"\n  }\n}\n"
+	expected := `eventID: "test-event"
+sourceID: "test-source"
+timestamp: 946688523
+eventType: EVENT_TYPE_ONE
+data: ""
+[crowdstrike.csproto.example.proto2.googlev1.TestEvent.eventExt]: {
+  name: "test"
+  info: ""
+  labels: "one"
+  labels: "two"
+  labels: "three"
+  embedded: {
+    ID: 42
+    stuff: "some stuff"
+    favoriteNumbers: 42
+    favoriteNumbers: 1138
+  }
+  jedi: true
+  nested: {
+    details: "these are some nested details"
+  }
+}
+`
 
 	s, err := csproto.MarshalText(msg)
 	// replace ":  " with ": " to undo the Google library's intentional randomization of the output :(

--- a/example/proto2_googlev2_test.go
+++ b/example/proto2_googlev2_test.go
@@ -145,7 +145,7 @@ func TestProto2GoogleV2MarshalJSON(t *testing.T) {
 			Name:      csproto.String("enable-all"),
 			EventType: &etype,
 		}
-		expected := fmt.Sprintf("{\n  \"eventType\":0,\"name\":\"enable-all\",\n  \"ts\":null\n}")
+		expected := "{\n  \"eventType\":0,\"name\":\"enable-all\",\n  \"ts\":null\n}"
 
 		opts := []csproto.JSONOption{
 			csproto.JSONIndent("  "),
@@ -257,7 +257,29 @@ func TestProto2GoogleV2MarshalText(t *testing.T) {
 	// - this string matches google.golang.org/protobuf@v1.28.1
 	// - if this test breaks after updating google.golang.org/protobuf, then update the expected string
 	//   accordingly
-	expected := "eventID: \"test-event\"\nsourceID: \"test-source\"\ntimestamp: 946688523\neventType: EVENT_TYPE_ONE\ndata: \"\"\n[crowdstrike.csproto.example.proto2.googlev2.TestEvent.eventExt]: {\n  name: \"test\"\n  info: \"\"\n  labels: \"one\"\n  labels: \"two\"\n  labels: \"three\"\n  embedded: {\n    ID: 42\n    stuff: \"some stuff\"\n    favoriteNumbers: 42\n    favoriteNumbers: 1138\n  }\n  jedi: true\n  nested: {\n    details: \"these are some nested details\"\n  }\n}\n"
+	expected := `eventID: "test-event"
+sourceID: "test-source"
+timestamp: 946688523
+eventType: EVENT_TYPE_ONE
+data: ""
+[crowdstrike.csproto.example.proto2.googlev2.TestEvent.eventExt]: {
+  name: "test"
+  info: ""
+  labels: "one"
+  labels: "two"
+  labels: "three"
+  embedded: {
+    ID: 42
+    stuff: "some stuff"
+    favoriteNumbers: 42
+    favoriteNumbers: 1138
+  }
+  jedi: true
+  nested: {
+    details: "these are some nested details"
+  }
+}
+`
 
 	s, err := csproto.MarshalText(msg)
 	// replace ":  " with ": " to undo the Google library's intentional randomization of the output :(

--- a/example/proto3_gogo_test.go
+++ b/example/proto3_gogo_test.go
@@ -117,7 +117,7 @@ func TestProto3GogoMarshalJSON(t *testing.T) {
 			Name:      "enable-all",
 			EventType: etype,
 		}
-		expected := fmt.Sprintf("{\n  \"name\": \"enable-all\",\n  \"ts\": null,\n  \"eventType\": 0\n}")
+		expected := "{\n  \"name\": \"enable-all\",\n  \"ts\": null,\n  \"eventType\": 0\n}"
 
 		opts := []csproto.JSONOption{
 			csproto.JSONIndent("  "),
@@ -231,7 +231,24 @@ func TestProto3GogoMarshalText(t *testing.T) {
 	// - this string matches gogo/protobuf@v1.3.2
 	// - if this test breaks after updating gogo/protobuf, then update the expected string
 	//   accordingly
-	expected := "name: \"test\"\nlabels: \"one\"\nlabels: \"two\"\nlabels: \"three\"\nembedded: <\n  ID: 42\n  stuff: \"some stuff\"\n  favoriteNumbers: 42\n  favoriteNumbers: 1138\n>\njedi: true\nnested: <\n  details: \"these are some nested details\"\n>\nts: <\n  seconds: 946688523\n>\n"
+	expected := `name: "test"
+labels: "one"
+labels: "two"
+labels: "three"
+embedded: <
+  ID: 42
+  stuff: "some stuff"
+  favoriteNumbers: 42
+  favoriteNumbers: 1138
+>
+jedi: true
+nested: <
+  details: "these are some nested details"
+>
+ts: <
+  seconds: 946688523
+>
+`
 
 	s, err := csproto.MarshalText(msg)
 

--- a/example/proto3_googlev1_test.go
+++ b/example/proto3_googlev1_test.go
@@ -121,7 +121,7 @@ func TestProto3GoogleV1MarshalJSON(t *testing.T) {
 			Name:      "enable-all",
 			EventType: etype,
 		}
-		expected := fmt.Sprintf("{\n  \"name\": \"enable-all\",\n  \"ts\": null,\n  \"eventType\": 0\n}")
+		expected := "{\n  \"name\": \"enable-all\",\n  \"ts\": null,\n  \"eventType\": 0\n}"
 
 		opts := []csproto.JSONOption{
 			csproto.JSONIndent("  "),
@@ -235,7 +235,24 @@ func TestProto3GoogleV1MarshalText(t *testing.T) {
 	// - this string matches github.com/golang/protobuf@v1.5.2
 	// - if this test breaks after updating golang/protobuf, then update the expected string
 	//   accordingly
-	expected := "name: \"test\"\nlabels: \"one\"\nlabels: \"two\"\nlabels: \"three\"\nembedded: {\n  ID: 42\n  stuff: \"some stuff\"\n  favoriteNumbers: 42\n  favoriteNumbers: 1138\n}\njedi: true\nnested: {\n  details: \"these are some nested details\"\n}\nts: {\n  seconds: 946688523\n}\n"
+	expected := `name: "test"
+labels: "one"
+labels: "two"
+labels: "three"
+embedded: {
+  ID: 42
+  stuff: "some stuff"
+  favoriteNumbers: 42
+  favoriteNumbers: 1138
+}
+jedi: true
+nested: {
+  details: "these are some nested details"
+}
+ts: {
+  seconds: 946688523
+}
+`
 
 	s, err := csproto.MarshalText(msg)
 	// replace ":  " with ": " to undo the Google library's intentional randomization of the output :(

--- a/example/proto3_googlev2_test.go
+++ b/example/proto3_googlev2_test.go
@@ -126,7 +126,7 @@ func TestProto3GoogleV2MarshalJSON(t *testing.T) {
 			Name:      "enable-all",
 			EventType: etype,
 		}
-		expected := fmt.Sprintf("{\n  \"name\": \"enable-all\",\n  \"ts\": null,\n  \"eventType\": 0\n}")
+		expected := "{\n  \"name\": \"enable-all\",\n  \"ts\": null,\n  \"eventType\": 0\n}"
 
 		opts := []csproto.JSONOption{
 			csproto.JSONIndent("  "),
@@ -240,7 +240,24 @@ func TestProto3GoogleV2MarshalText(t *testing.T) {
 	// - this string matches google.golang.org/protobuf@v1.28.1
 	// - if this test breaks after updating google.golang.org/protobuf, then update the expected string
 	//   accordingly
-	expected := "name: \"test\"\nlabels: \"one\"\nlabels: \"two\"\nlabels: \"three\"\nembedded: {\n  ID: 42\n  stuff: \"some stuff\"\n  favoriteNumbers: 42\n  favoriteNumbers: 1138\n}\njedi: true\nnested: {\n  details: \"these are some nested details\"\n}\nts: {\n  seconds: 946688523\n}\n"
+	expected := `name: "test"
+labels: "one"
+labels: "two"
+labels: "three"
+embedded: {
+  ID: 42
+  stuff: "some stuff"
+  favoriteNumbers: 42
+  favoriteNumbers: 1138
+}
+jedi: true
+nested: {
+  details: "these are some nested details"
+}
+ts: {
+  seconds: 946688523
+}
+`
 
 	s, err := csproto.MarshalText(msg)
 	// replace ":  " with ": " to undo the Google library's intentional randomization of the output :(

--- a/prototest/parse_annotated_hex.go
+++ b/prototest/parse_annotated_hex.go
@@ -1,0 +1,78 @@
+package prototest
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// ParseAnnotatedHex takes a string containing formatted, indented, and commented (via ;) hexadecimal
+// and returns the raw hex bytes by stripping the comments and whitespace.
+//
+// This function is provided to make it a little easier for humans to create test data.  Consumers will
+// still need to be able to create the correct hex bytes for the various test messages based on the required
+// Protobuf encoding, but this function allows those bytes to be interleaved with line breaks, indentation,
+// and comments.
+//
+// Each line in the string is processed as follows:
+//   - A semi-colon (';') character starts a comment.
+//   - Comments and spaces are removed.
+//   - The remaining string is treated as a sequence of hex digits, which are parsed using [encoding/hex.DecodeString].
+//   - The resulting bytes are appended to the result.
+//
+// An error is returned if the string contains any characters other than hex digits or spaces that are
+// not part of a comment.
+//
+// As an example, below are 2 equally valid instances of the hex-encoded data for Protobuf message.
+// The second, annotated data is more human-friendly.
+//
+//	Raw Hex:
+//		08 64 A2 06 12 08 01 12 0E 30 01 D0 04 01 BA 1F 03 66 6F 6F C0 2E 01
+//	Annotated Hex:
+//		; Foo message
+//		08 				; tag=1, enum
+//		  64 			; value=100
+//		A2 06 			; tag=100, nested message
+//		  12 			; len=18
+//		  ; Bar message
+//		  08 			; tag=1, uint64
+//		    01 			; value=1
+//		  12 			; tag=2, bytes (encoded message data)
+//		    0E 			; len=14
+//			; Baz message
+//		    30 			; tag=6, uint32
+//		      01 		; value=1
+//		    D0 04 		; tag=74, uint64
+//		      01 		; value=1
+//		    BA 1F 		; tag=503, string
+//		      03 		; len=3
+//		      66 6F 6F 	; "foo"
+//		    C0 2E 		; tag=744, uint32
+//		      01 		; value=1
+func ParseAnnotatedHex(x string) ([]byte, error) {
+	var data []byte
+	for i, line := range strings.Split(x, "\n") {
+		s := line
+		if i := strings.Index(s, ";"); i != -1 {
+			s = s[:i]
+		}
+		s = strings.Map(func(c rune) rune {
+			// remove any whitespace characters
+			// - not just spaces to account for editors that "helpfully" insert tabs
+			if unicode.IsSpace(c) {
+				return -1
+			}
+			return c
+		}, s)
+		if s == "" {
+			continue
+		}
+		b, err := hex.DecodeString(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid data at line %d: %w", i, err)
+		}
+		data = append(data, b...)
+	}
+	return data, nil
+}


### PR DESCRIPTION
This PR resolves a panic when trying to decode a corrupted message, specifically one where the encoded length of a string field is >2GB.

I also added a new `ParseAnnotatedHex()` function in a new `prototest` package.  This function can be used to convert a string containing a "commented" hexadecimal representation of an encoded Protobuf message into binary, which is useful for managing test data in a more human-readable form.  See the godoc comments on the function for more details.

Finally, I updated `.golangci.yml` to resolve some config deprecations, which led to having to update some test code that was now generating linter warnings.

Fixes #158 